### PR TITLE
Feature/check empty release variable

### DIFF
--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -7,6 +7,10 @@ variables:
   JDK_SELECTOR: "-PJDK=11"
   INSTALLER_ARTIFACT_PATH:  build/installers
   INSTALLER_GRADLE_COMMANDS: makeAllInstallers makeAllBundles
+  RELEASE:
+    value: ""
+    description: Determines what type of installer should be produced. Leave blank to produce a SNAPSHOT installer or enter
+    "true" to create a release installer.
 
 before_script:
   - export GRADLE_USER_HOME=/cache/.gradle

--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -9,8 +9,7 @@ variables:
   INSTALLER_GRADLE_COMMANDS: makeAllInstallers makeAllBundles
   RELEASE:
     value: ""
-    description: Determines what type of installer should be produced. Leave blank to produce a SNAPSHOT installer or enter
-    "true" to create a release installer.
+    description: Determines what type of installer should be produced. Leave blank to produce a SNAPSHOT installer or enter 'true' to create a release installer.
 
 before_script:
   - export GRADLE_USER_HOME=/cache/.gradle

--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -38,9 +38,11 @@ before_script:
 .base-snapshot-installer:
   extends: .base-installer
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_TAG == null && $RELEASE == null
+    - if: $RELEASE
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_TAG == null
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline") && $RELEASE == null
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline")
 
 jdk11-snapshot-installer:
   extends: .base-snapshot-installer


### PR DESCRIPTION
- Updated the rules for snapshot jobs to ensure snapshots aren't built when the release variable is set to empty string
- Added a release variable declaration so it will always appear in the manual pipeline UI by default. Since the default value is an empty string this won't change the default behavior of the rules.

Tested that not setting the release variable triggers only the SNAPSHOT job [here](https://git.tak.gov/raptor/installers/gitlab-installer-template-test/-/pipelines/61358).
Tested that setting the release variable triggers only the RELEASE job [here](https://git.tak.gov/raptor/installers/gitlab-installer-template-test/-/pipelines/61359)