### PR TITLE
Add Zac to CODEOWNERS to help DevSecOps keep in touch with Gitlab tem…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @CorriganRJ @eventuri
+*       @CorriganRJ @eventuri @pieckle
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
…plates.