### PR TITLE
Add changes for build errors

### DIFF
--- a/lib/gitlab/ci/templates/jobs/docker/Kaniko.yml
+++ b/lib/gitlab/ci/templates/jobs/docker/Kaniko.yml
@@ -1,12 +1,15 @@
 kaniko_publish:
   stage: publish
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [ "" ]
+
   script:
-    - apk add img
     - if [[ $DOCKER_DIRECTORY ]]; then cd $DOCKER_DIRECTORY; fi;
     - mkdir -p /kaniko/.docker
     - if [ -f "${REGISTRY_CRT}" ]; then cat "${REGISTRY_CRT}" >> /kaniko/ssl/certs/ca-certificates.crt; fi # supports self-signed registry
     - if [ -f "${DOCKER_AUTH_CONFIG}" ]; then echo "${DOCKER_AUTH_CONFIG}" > /kaniko/.docker/config.json; else echo "{\"auths\":{\"$DOCKER_REPO_HOSTNAME\":{\"username\":\"$DOCKER_REPO_USERNAME\",\"password\":\"$DOCKER_REPO_PASSWORD\"}}}" > /kaniko/.docker/config.json; fi
-    - /kaniko/executor --context $DOCKER_BUILD_CONTEXT --dockerfile . --destination $DOCKER_REPO_HOSTNAME/$DOCKER_REPO_NAME/$APP_NAME:$VERSION
+    - /kaniko/executor --context $CI_PROJECT_DIR --destination $DOCKER_REPO_HOSTNAME/$DOCKER_REPO_NAME/$APP_NAME:$VERSION
 
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH  # Run this job when commits are pushed or merged to the default branch


### PR DESCRIPTION
I was getting errors using this template and these changes should be all that's needed. I'm happy to discuss if there are any questions. Thanks! 

- Remove apk usage since it's not a part of the Kaniko image
- Use $CI_PROJECT_DIR variable instead of $DOCKER_BUILDCONTEXT. Will be the same docker context and CI_PROJECT_DIRECTORY is used by kaniko
- Remove dockerfile flag, it's not necessary
- Add executor image