### PR TITLE
Fix publishing to work for BSP and non BSP projects.

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -131,7 +131,7 @@ publish_release_jar:
     # checkout a named branch instead of a SHA (to keep the BSP happy)
     - echo "Check out $CI_COMMIT_BRANCH"
     - git checkout -q -b $CI_COMMIT_BRANCH origin/$CI_COMMIT_BRANCH
-    - ./gradlew $STANDARD_GRADLE_FLAGS $RELEASE_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -Pforce -Prelease $RC_FLAG build
+    - ./gradlew $STANDARD_GRADLE_FLAGS $RELEASE_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -Pforce -Prelease $RC_FLAG publish
   rules:
     - if: '$PUBLISH_RELEASE_JAR_DISABLED =~ /true/i'
       when: never


### PR DESCRIPTION
We were simply calling build instead of publish when doing releases