### PR TITLE
Execute the build task before publish

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -97,7 +97,7 @@ publish_snapshot_jar:
   script:
     - echo "CI Pipeline Source = '$CI_PIPELINE_SOURCE'"
     - echo "Publishing with flags '$STANDARD_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS'"
-    - ./gradlew $STANDARD_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -PforcePublish -Pgitlab -Pjenkins publish
+    - ./gradlew $STANDARD_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -PforcePublish -Pgitlab -Pjenkins build publish
   rules:
     - if: '$PUBLISH_SNAPSHOT_JAR_DISABLED =~ /true/i'
       when: never
@@ -131,7 +131,7 @@ publish_release_jar:
     # checkout a named branch instead of a SHA (to keep the BSP happy)
     - echo "Check out $CI_COMMIT_BRANCH"
     - git checkout -q -B $CI_COMMIT_BRANCH origin/$CI_COMMIT_BRANCH
-    - ./gradlew $STANDARD_GRADLE_FLAGS $RELEASE_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -Pforce -Prelease $RC_FLAG publish
+    - ./gradlew $STANDARD_GRADLE_FLAGS $RELEASE_GRADLE_FLAGS $PUBLISH_SNAPSHOT_GRADLE_FLAGS -Pforce -Prelease $RC_FLAG build publish
   rules:
     - if: '$PUBLISH_RELEASE_JAR_DISABLED =~ /true/i'
       when: never


### PR DESCRIPTION
Execute the build task before publish since some of the task dependencies are on the build task, not publish (e.g. tagRelease)

This should resolve an issue with releases not being tagged in Git when a release build is completed. The tagRelease task was not being run since it is not part of the publish dependency tree (though maybe it should be).