### PR TITLE
Added quotes around the test of regex to commit branch equivaliency. …

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -116,7 +116,7 @@ publish_release_jar:
   script:
     - apt-get update
     - apt-get -y install git
-    - if [[ $CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX ]]; then IS_RELEASE_BRANCH="true"; else IS_RELEASE_BRANCH=""; fi
+    - if [[ '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX' ]]; then IS_RELEASE_BRANCH="true"; else IS_RELEASE_BRANCH=""; fi
     - if [[ -z "$IS_RELEASE_BRANCH" ]]; then
       echo "You can not run release builds off of branch $CI_COMMIT_BRANCH";
       exit 1;


### PR DESCRIPTION
…Tested using a merge yaml file and it seems to fix the regex issue when the regex is defined as a variable outside this project.