### PR TITLE
Make publish pages its own job and handle n tier gradle sub projects

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -58,7 +58,7 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -58,7 +58,7 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -58,7 +58,7 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -48,11 +48,11 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
     - python3 create_aggregate_license_page.py
     - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
     - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/* public/coverage

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -55,7 +55,7 @@ pages:
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
     - python3 create_aggregate_license_page.py
     - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
-    - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
+    - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/* public/coverage
     - test -e $ROOT_PROJECT_DIR/build/reports/dependency-license && cp -R $ROOT_PROJECT_DIR/build/reports/dependency-license/* public/dependency-licenses
     - test -e gl-dependency-scanning-report.html && cp gl-dependency-scanning-report.html public/dependency-vulnerabilities
     - test -e gl-sast-report.html && cp gl-sast-report.html public/source-vulnerabilities

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -46,7 +46,7 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -1,0 +1,81 @@
+pages_generate:
+  stage: publish
+  rules:
+    - if: '$FORCE_PUBLISH_PAGES =~ /true/i'
+    - if: '$PUBLISH_JAVADOCS_DISABLED =~ /true/i'
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
+  script:
+    - echo "CI Pipeline Source = '$CI_PIPELINE_SOURCE'"
+    - ./gradlew javadoc -x build -x test
+    - ./gradlew compileJava javadoc -x test
+
+  artifacts:
+    paths:
+      - "build/docs/javadoc"
+      - "**/build/docs/javadoc"
+      - "build/reports"
+      - "**/build/reports"
+
+
+pages:
+  image: "${IMAGE_PREFIX}python:3.11-rc-alpine"
+  stage: deploy
+  rules:
+    - if: '$FORCE_PUBLISH_PAGES =~ /true/i'
+    - if: '$PUBLISH_JAVADOCS_DISABLED =~ /true/i'
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
+  script:
+    - echo "CI Pipeline Source = '$CI_PIPELINE_SOURCE'"
+    - rm -rf public
+    - mkdir public
+    - mkdir public/javadocs
+    - mkdir public/coverage
+    - mkdir public/quality
+    - mkdir public/dependency-licenses
+    - mkdir public/dependency-vulnerabilities
+    - mkdir public/source-vulnerabilities
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - python3 create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
+    - python3 create_aggregate_quality_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
+    - python3 create_aggregate_license_page.py
+    - test -e build/reports/jacoco/test/html/ && cp -R build/reports/jacoco/test/html/* public/coverage
+    - test -e build/reports/dependency-license && cp -R build/reports/dependency-license/* public/dependency-licenses
+    - test -e gl-dependency-scanning-report.html && cp gl-dependency-scanning-report.html public/dependency-vulnerabilities
+    - test -e gl-sast-report.html && cp gl-sast-report.html public/source-vulnerabilities
+    - |
+      cat > public/index.html <<EOF
+      <html>
+      <head>
+        <title>Repo Resources</title>
+      </head>
+      <body>
+      <h1><a href="./javadocs/index.html">Javadocs</a></h1>
+      <h1><a href="./coverage/index.html">Jacoco Test Coverage</a></h1>
+      <h1><a href="./quality/index.html">PMD Code Quality</a></h1>
+      <h1><a href="./dependency-licenses/index.html">Dependency Licenses</a></h1>
+      <h1><a href="./dependency-vulnerabilities/gl-dependency-scanning-report.html">Dependency Vulnerabilities</a></h1>
+      <h1><a href="./source-vulnerabilities/gl-sast-report.html">Source Vulnerabilities</a></h1>
+      </body>
+      </html>
+      EOF
+  artifacts:
+    paths:
+      - "build/docs/javadoc"
+      - "**/build/docs/javadoc"
+      - "build/reports"
+      - "**/build/reports"
+      - public

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -26,6 +26,8 @@ pages_generate:
 pages:
   image: "${IMAGE_PREFIX}python:3.11-rc-alpine"
   stage: deploy
+  variables:
+    ROOT_PROJECT_DIR: $CI_PROJECT_DIR
   rules:
     - if: '$FORCE_PUBLISH_PAGES =~ /true/i'
     - if: '$PUBLISH_JAVADOCS_DISABLED =~ /true/i'
@@ -52,8 +54,9 @@ pages:
     - python3 create_aggregate_quality_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
     - python3 create_aggregate_license_page.py
-    - test -e build/reports/jacoco/test/html/ && cp -R build/reports/jacoco/test/html/* public/coverage
-    - test -e build/reports/dependency-license && cp -R build/reports/dependency-license/* public/dependency-licenses
+    - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
+    - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
+    - test -e $ROOT_PROJECT_DIR/build/reports/dependency-license && cp -R $ROOT_PROJECT_DIR/build/reports/dependency-license/* public/dependency-licenses
     - test -e gl-dependency-scanning-report.html && cp gl-dependency-scanning-report.html public/dependency-vulnerabilities
     - test -e gl-sast-report.html && cp gl-sast-report.html public/source-vulnerabilities
     - |

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -46,11 +46,11 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
     - python3 create_aggregate_license_page.py
     - test -e build/reports/jacoco/test/html/ && cp -R build/reports/jacoco/test/html/* public/coverage
     - test -e build/reports/dependency-license && cp -R build/reports/dependency-license/* public/dependency-licenses

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -46,7 +46,7 @@ pages:
     - mkdir public/dependency-licenses
     - mkdir public/dependency-vulnerabilities
     - mkdir public/source-vulnerabilities
-    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+    - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/make-publish-pages-its-own-job-and-handle-n-tier-gradle-sub-projects/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
     - python3 create_aggregate_javadoc_page.py
     - wget https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
     - python3 create_aggregate_quality_page.py

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -35,6 +35,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/gradle/GradleWrapperSetup.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/Test.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -35,7 +35,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/references/gradle/GradleWrapperSetup.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/Test.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/test-page-publishing/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -11,11 +11,10 @@ for root, dirs, files in os.walk("./"):
         index_path = os.path.join(root, file)
         if "/build/docs/javadoc/index.html" in index_path:
              logging.info('Found index.html at %s', index_path)
-             module = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
-             module = module.rsplit('/',1)[-1]
-             logging.info('Module rename is %s', module)
+             index_path_trimmed = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
+             module = index_path_trimmed.rsplit('/',1)[-1]
              index_directory = index_path.replace("index.html", "")
-             logging.info('Index directory is %s', index_directory)
+             logging.info('Module name found is %s for index directory %s', module, index_directory)
              module_to_index_directory[module] = index_directory
 
 logging.info('Writing base JavaDoc index html')
@@ -27,18 +26,12 @@ index_html_output.write("</head>\n")
 index_html_output.write("<body>\n")
 
 for module, index_directory in module_to_index_directory.items():
-    logging.info('Module is %s', module)
-    logging.info('Index directory is %s', index_directory)
     destination_directory = "public/javadocs/"+module
-    logging.info('Destination directory is %s', destination_directory)
+    logging.info('For module %s the index directroy is %s and the destination directory is %s', module, index_directory, destination_directory)
     shutil.copytree(index_directory, destination_directory)
-    logging.info('Copied from index to destination directory')
     value_index = '<h1><a href="./' + module + '/index.html">' + module + '</a></h1>\n'
-    logging.info('Value index is %s', value_index)
     index_html_output.write(value_index)
-    logging.info('Work index html out')
 
-logging.info('Writing finishing index html')
 index_html_output.write("</body>\n")
 index_html_output.write("</html>\n")
 index_html_output.close()

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -12,7 +12,6 @@ for root, dirs, files in os.walk("./"):
         if "/build/docs/javadoc/index.html" in index_path:
              logging.info('Found index.html at %s', index_path)
              module = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
-             module = module.rsplit('/',1)
              module = module.rsplit('/',1)[1]
              logging.info('Module rename is %s', module)
              index_directory = index_path.replace("index.html", "")

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import logging
 
 module_to_index_directory = {}
 
@@ -7,10 +8,14 @@ for root, dirs, files in os.walk("./"):
     for file in files:
         index_path = os.path.join(root, file)
         if "/build/docs/javadoc/index.html" in index_path:
+             logging.info('Found index.html at %s', index_path)
              module = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
+             logging.info('Module rename is %s', module)
              index_directory = index_path.replace("index.html", "")
+             logging.info('Index directory is %s', index_directory)
              module_to_index_directory[module] = index_directory
 
+logging.info('Writing base JavaDoc index html')
 index_html_output = open("public/javadocs/index.html","w")
 index_html_output.write("<html>\n")
 index_html_output.write("<head>\n")
@@ -19,11 +24,19 @@ index_html_output.write("</head>\n")
 index_html_output.write("<body>\n")
 
 for module, index_directory in module_to_index_directory.items():
+    logging.info('Module is %s', module)
+    logging.info('Index directory is %s', index_directory)
     destination_directory = "public/javadocs/"+module
+    logging.info('Destination directory is %s', destination_directory)
     shutil.copytree(index_directory, destination_directory)
+    logging.info('Copied from index to destination directory')
     value_index = '<h1><a href="./' + module + '/index.html">' + module + '</a></h1>\n'
+    logging.info('Value index is %s', value_index)
     index_html_output.write(value_index)
+    logging.info('Work index html out')
 
+logging.info('Writing finishing index html')
 index_html_output.write("</body>\n")
 index_html_output.write("</html>\n")
 index_html_output.close()
+logging.info('Closing html out')

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -27,7 +27,7 @@ index_html_output.write("<body>\n")
 
 for module, index_directory in module_to_index_directory.items():
     destination_directory = "public/javadocs/"+module
-    logging.info('For module %s the index directroy is %s and the destination directory is %s', module, index_directory, destination_directory)
+    logging.info('For module %s the index directory is %s and the destination directory is %s', module, index_directory, destination_directory)
     shutil.copytree(index_directory, destination_directory)
     value_index = '<h1><a href="./' + module + '/index.html">' + module + '</a></h1>\n'
     index_html_output.write(value_index)

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import logging
 
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
 module_to_index_directory = {}
 
 for root, dirs, files in os.walk("./"):

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -12,6 +12,8 @@ for root, dirs, files in os.walk("./"):
         if "/build/docs/javadoc/index.html" in index_path:
              logging.info('Found index.html at %s', index_path)
              module = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
+             module = module.rsplit('/',1)
+             module = module.rsplit('/',1)[1]
              logging.info('Module rename is %s', module)
              index_directory = index_path.replace("index.html", "")
              logging.info('Index directory is %s', index_directory)

--- a/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
+++ b/lib/gitlab/ci/templates/references/javadoc/create_aggregate_javadoc_page.py
@@ -12,7 +12,7 @@ for root, dirs, files in os.walk("./"):
         if "/build/docs/javadoc/index.html" in index_path:
              logging.info('Found index.html at %s', index_path)
              module = index_path.replace("./", "").replace("/build/docs/javadoc/index.html", "")
-             module = module.rsplit('/',1)[1]
+             module = module.rsplit('/',1)[-1]
              logging.info('Module rename is %s', module)
              index_directory = index_path.replace("index.html", "")
              logging.info('Index directory is %s', index_directory)

--- a/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
+++ b/lib/gitlab/ci/templates/references/license/create_aggregate_license_page.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import logging
+
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 module_to_index_directory = {}
 
@@ -7,10 +10,14 @@ for root, dirs, files in os.walk("./"):
     for file in files:
         index_path = os.path.join(root, file)
         if "/build/reports/dependency-license/index.html" in index_path:
-             module = index_path.replace("./", "").replace("/build/reports/dependency-license/index.html", "")
+             logging.info('Found index.html at %s', index_path)
+             index_path_trimmed = index_path.replace("./", "").replace("/build/reports/dependency-license/index.html", "")
+             module = index_path_trimmed.rsplit('/',1)[-1]
              index_directory = index_path.replace("index.html", "")
+             logging.info('Module name found is %s for index directory %s', module, index_directory)
              module_to_index_directory[module] = index_directory
 
+logging.info('Writing base license index html')
 index_html_output = open("public/dependency-licenses/index.html","w")
 index_html_output.write("<html>\n")
 index_html_output.write("<head>\n")
@@ -19,8 +26,8 @@ index_html_output.write("</head>\n")
 index_html_output.write("<body>\n")
 
 for module, index_directory in module_to_index_directory.items():
-    print(module, index_directory)
     destination_directory = "public/dependency-licenses/"+module
+    logging.info('For module %s the index directory is %s and the destination directory is %s', module, index_directory, destination_directory)
     shutil.copytree(index_directory, destination_directory)
     value_index = '<h1><a href="./' + module + '/index.html">' + module + '</a></h1>\n'
     index_html_output.write(value_index)
@@ -28,3 +35,4 @@ for module, index_directory in module_to_index_directory.items():
 index_html_output.write("</body>\n")
 index_html_output.write("</html>\n")
 index_html_output.close()
+logging.info('Closing html out')

--- a/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
+++ b/lib/gitlab/ci/templates/references/quality/create_aggregate_quality_page.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import logging
+
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 module_to_index_directory = {}
 
@@ -7,10 +10,14 @@ for root, dirs, files in os.walk("./"):
     for file in files:
         index_path = os.path.join(root, file)
         if "/build/reports/pmd/main.html" in index_path:
-             module = index_path.replace("./", "").replace("/build/reports/pmd/main.html", "")
+             logging.info('Found main.html at %s', index_path)
+             index_path_trimmed = index_path.replace("./", "").replace("/build/reports/pmd/main.html", "")
+             module = index_path_trimmed.rsplit('/',1)[-1]
              index_directory = index_path.replace("main.html", "")
+             logging.info('Module name found is %s for index directory %s', module, index_directory)
              module_to_index_directory[module] = index_directory
 
+logging.info('Writing base quality index html')
 index_html_output = open("public/quality/index.html","w")
 index_html_output.write("<html>\n")
 index_html_output.write("<head>\n")
@@ -19,8 +26,8 @@ index_html_output.write("</head>\n")
 index_html_output.write("<body>\n")
 
 for module, index_directory in module_to_index_directory.items():
-    print(module, index_directory)
     destination_directory = "public/quality/"+module
+    logging.info('For module %s the index directory is %s and the destination directory is %s', module, index_directory, destination_directory)
     shutil.copytree(index_directory, destination_directory)
     value_index = '<h1><a href="./' + module + '/main.html">' + module + '</a></h1>\n'
     index_html_output.write(value_index)
@@ -28,3 +35,4 @@ for module, index_directory in module_to_index_directory.items():
 index_html_output.write("</body>\n")
 index_html_output.write("</html>\n")
 index_html_output.close()
+logging.info('Closing html out')


### PR DESCRIPTION
This pull request is for three things. 

1. Making publishJar into two separate publishJar and publishPages jobs so that publishPages can be used without publishJar.  
2. Getting publishPages to work with n-tiered gradle sub-projects instead of just 2-tiers. 
3. Get publishPages to work with a custom root source directory (e.g., having the root build.gradle in ./src/build.gradle instead of at the typically ./build.gradle. 