### PR TITLE
Move ansible to mega linter

### DIFF
--- a/lib/gitlab/ci/templates/jobs/ansible/PlaybookDeploy.yml
+++ b/lib/gitlab/ci/templates/jobs/ansible/PlaybookDeploy.yml
@@ -1,0 +1,49 @@
+variables:
+  ANSIBLE_ROOT: ${CI_PROJECT_DIR}
+  ANSIBLE_PLAYBOOK: playbook.yml
+  IMAGE_PREFIX: ""
+  DEFAULT_IMAGE: "python:3.11-rc-alpine"
+  ANSIBLE_CONFIG: ./ansible.cfg
+  ANSIBLE_LOG_PATH: ~/ansible.log
+  ANSIBLE_DEBUG: "True"
+  ANSIBLE_PLAYBOOK_EXTRA_VARS: ""
+  SSH_PRIVATE_KEY:
+    value: ""
+    description: The SSH private key so Ansible can interact with the VM
+  SSH_PRIVATE_KEY_FILENAME:
+    value: ""
+    description: The SSH private key filename so that Ansible can interact with the VM
+  SERVER_HOST_IPS:
+    value: ""
+    description: Known host IPs of the Azure VMs
+
+default:
+  image:
+    name: ${IMAGE_PREFIX}$DEFAULT_IMAGE
+    entrypoint:
+      - 'usr/bin/env'
+      - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
+ansible_playbook_deploy:
+  stage: deploy
+  before_script:
+    - apk update
+    - 'which ssh-agent || ( apk update && apk add openssh-client )'
+    - mkdir -p ~/.ssh
+    - eval $(ssh-agent -s)
+    - echo "$SSH_PRIVATE_KEY" > ~/.ssh/$SSH_PRIVATE_KEY_FILENAME
+    - chmod 600 ~/.ssh/$SSH_PRIVATE_KEY_FILENAME
+    - |+
+      for ip in ${SERVER_HOST_IPS//,/ }
+      do
+          ssh-keyscan $ip >> ~/.ssh/known_hosts
+      done
+  script:
+    - cd "${ANSIBLE_ROOT}"
+    - apk add ansible
+    - ansible-playbook "${ANSIBLE_PLAYBOOK}" --extra-vars $ANSIBLE_PLAYBOOK_EXTRA_VARS
+  artifacts:
+    paths:
+      - $ANSIBLE_LOG_PATH
+  when:
+    manual

--- a/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
+++ b/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
@@ -1,0 +1,19 @@
+variables:
+  # Please see https://github.com/oxsecurity/megalinter for mega linter setting options
+  MEGA_LINTER_FILTER_REGEX_EXCLUDE: "()"
+  MEGA_LINTER_ENABLE: "JSON"
+
+mega-linter:
+  stage: test
+  allow_failure: true
+  image: "${IMAGE_PREFIX}nvuillam/mega-linter-python:v4"
+  script: ["/bin/bash /entrypoint.sh"]
+  variables:
+    DEFAULT_WORKSPACE: $CI_PROJECT_DIR
+    ENABLE: $MEGA_LINTER_ENABLE
+    FILTER_REGEX_EXCLUDE: $MEGA_LINTER_FILTER_REGEX_EXCLUDE
+  artifacts:
+    when: always
+    paths:
+      - "**/linters_logs/**"
+

--- a/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
+++ b/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
@@ -1,8 +1,3 @@
-variables:
-  # Please see https://github.com/oxsecurity/megalinter for mega linter setting options
-  MEGA_LINTER_FILTER_REGEX_EXCLUDE: "()"
-  MEGA_LINTER_ENABLE: "JSON"
-
 mega-linter:
   stage: test
   allow_failure: true
@@ -10,8 +5,9 @@ mega-linter:
   script: ["/bin/bash /entrypoint.sh"]
   variables:
     DEFAULT_WORKSPACE: $CI_PROJECT_DIR
-    ENABLE: $MEGA_LINTER_ENABLE
-    FILTER_REGEX_EXCLUDE: $MEGA_LINTER_FILTER_REGEX_EXCLUDE
+    # Please see https://github.com/oxsecurity/megalinter for mega linter setting options
+    ENABLE: "JSON"
+    FILTER_REGEX_EXCLUDE: (none)
   artifacts:
     when: always
     paths:

--- a/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
@@ -34,7 +34,7 @@ stages:
 
 mega-linter:
   variables:
-    ENABLE: ANSIBLE
+    MEGA_LINTER_ENABLE: ANSIBLE
 
 ansible_playbook_deploy:
   stage: deploy

--- a/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
@@ -20,4 +20,4 @@ stages:
 
 mega-linter:
   variables:
-    MEGA_LINTER_ENABLE: ANSIBLE
+    ENABLE: ANSIBLE

--- a/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
@@ -1,6 +1,6 @@
 variables:
   ANSIBLE_ROOT: ${CI_PROJECT_DIR}
-  ANSIBLE_LINT_PLAYBOOK: playbook.yml
+  ANSIBLE_PLAYBOOK: playbook.yml
   IMAGE_PREFIX: ""
   DEFAULT_IMAGE: "python:3.11-rc-alpine"
   ANSIBLE_CONFIG: ./ansible.cfg
@@ -26,27 +26,15 @@ default:
 
 include:
   - template: Security/SAST-IaC.gitlab-ci.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/move-ansible-to-mega-linter/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
 
 stages:
-  - lint
   - test
   - deploy
 
-ansible_lint:
-  stage: lint
-  allow_failure: true
-  artifacts:
-    paths:
-      - ansible-lint
-    when: always
-  before_script:
-    - python3 -m pip -V
-    - apk add ansible
-    - pip3 install "ansible-lint"
-  script:
-    - cd "${ANSIBLE_ROOT}"
-    - mkdir -p ansible-lint
-    - ansible-lint -p "${ANSIBLE_LINT_PLAYBOOK}" | tee "ansible-lint/${CI_PROJECT_NAME}.txt"
+mega-linter:
+  variables:
+    ENABLE: ANSIBLE
 
 ansible_playbook_deploy:
   stage: deploy
@@ -65,7 +53,7 @@ ansible_playbook_deploy:
   script:
     - cd "${ANSIBLE_ROOT}"
     - apk add ansible
-    - ansible-playbook "${ANSIBLE_LINT_PLAYBOOK}" -e $ANSIBLE_PLAYBOOK_EXTRA_VARS
+    - ansible-playbook "${ANSIBLE_PLAYBOOK}" --extra-vars $ANSIBLE_PLAYBOOK_EXTRA_VARS
   artifacts:
     paths:
       - $ANSIBLE_LOG_PATH

--- a/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
@@ -1,21 +1,6 @@
 variables:
-  ANSIBLE_ROOT: ${CI_PROJECT_DIR}
-  ANSIBLE_PLAYBOOK: playbook.yml
   IMAGE_PREFIX: ""
   DEFAULT_IMAGE: "python:3.11-rc-alpine"
-  ANSIBLE_CONFIG: ./ansible.cfg
-  ANSIBLE_LOG_PATH: ~/ansible.log
-  ANSIBLE_DEBUG: "True"
-  ANSIBLE_PLAYBOOK_EXTRA_VARS: ""
-  SSH_PRIVATE_KEY:
-    value: ""
-    description: The SSH private key so Ansible can interact with the VM
-  SSH_PRIVATE_KEY_FILENAME:
-    value: ""
-    description: The SSH private key filename so that Ansible can interact with the VM
-  SERVER_HOST_IPS:
-    value: ""
-    description: Known host IPs of the Azure VMs
 
 default:
   image:
@@ -27,6 +12,7 @@ default:
 include:
   - template: Security/SAST-IaC.gitlab-ci.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/move-ansible-to-mega-linter/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/move-ansible-to-mega-linter/lib/gitlab/ci/templates/jobs/ansible/PlaybookDeploy.yml
 
 stages:
   - test
@@ -35,27 +21,3 @@ stages:
 mega-linter:
   variables:
     MEGA_LINTER_ENABLE: ANSIBLE
-
-ansible_playbook_deploy:
-  stage: deploy
-  before_script:
-    - apk update
-    - 'which ssh-agent || ( apk update && apk add openssh-client )'
-    - mkdir -p ~/.ssh
-    - eval $(ssh-agent -s)
-    - echo "$SSH_PRIVATE_KEY" > ~/.ssh/$SSH_PRIVATE_KEY_FILENAME
-    - chmod 600 ~/.ssh/$SSH_PRIVATE_KEY_FILENAME
-    - |+
-      for ip in ${SERVER_HOST_IPS//,/ }
-      do
-          ssh-keyscan $ip >> ~/.ssh/known_hosts
-      done
-  script:
-    - cd "${ANSIBLE_ROOT}"
-    - apk add ansible
-    - ansible-playbook "${ANSIBLE_PLAYBOOK}" --extra-vars $ANSIBLE_PLAYBOOK_EXTRA_VARS
-  artifacts:
-    paths:
-      - $ANSIBLE_LOG_PATH
-  when:
-    manual

--- a/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/AnsiblePipeline.yml
@@ -11,8 +11,8 @@ default:
 
 include:
   - template: Security/SAST-IaC.gitlab-ci.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/move-ansible-to-mega-linter/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/move-ansible-to-mega-linter/lib/gitlab/ci/templates/jobs/ansible/PlaybookDeploy.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/lint/MegaLinter.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/1.3/lib/gitlab/ci/templates/jobs/ansible/PlaybookDeploy.yml
 
 stages:
   - test


### PR DESCRIPTION
This pull request moves the Ansible pipeline from ansible-lint to mega-linter (see https://github.com/oxsecurity/megalinter for capabilities). Also this pull request breaks the Ansible pipeline into individual jobs. 