### PR TITLE
Feature/add release regex to installer pipeline

### DIFF
--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -27,7 +27,7 @@ before_script:
   stage: build
   script:
     # Only publish when building develop or a release branch
-    - if [[ '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX' ]]; then PUBLISH="publish"; else PUBLISH="-x publish"; fi
+    - if [[ $CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX ]]; then PUBLISH="publish"; else PUBLISH="-x publish"; fi
     - echo "Build with SNAPSHOT_FLAGS='$SNAPSHOT_FLAGS' JDK_SELECTOR='$JDK_SELECTOR' PUBLISH='$PUBLISH' using flags '$GRADLE_FLAGS'"
     - ./gradlew $GRADLE_FLAGS $SNAPSHOT_FLAGS $JDK_SELECTOR -Pi4jLicenseKey=${I4J_LICENSE_KEY} $INSTALLER_GRADLE_COMMANDS $PUBLISH
   variables:

--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -2,7 +2,7 @@ variables:
   STANDARD_GRADLE_FLAGS: '-s --no-daemon -PnoMavenLocal -PforcePublish --console=plain --refresh-dependencies'
   GRADLE_FLAGS: "$STANDARD_GRADLE_FLAGS $EXTRA_GRADLE_FLAGS"
   INSTALL4J_VERSION: "unix_8_0_11"
-  DEV_OR_RELEASE_REGEX: '^develop$|^[0-9]+\.[0-9]+$|^release\/.+$'
+  DEV_OR_RELEASE_REGEX: '^develop$|^[0-9]+\.[0-9]+$|^release\/.+$|^support\/.+$'
   DEFAULT_INSTALL4J_IMAGE: devsecops/install4j8:1.0.0-jdk11-slim-custom
   JDK_SELECTOR: "-PJDK=11"
   INSTALLER_ARTIFACT_PATH:  build/installers


### PR DESCRIPTION
This merge request adds "support" to the install4j pipeline regex. This merge request also fixes a bug where installer snapshots were being pushed on every commit, not just to the develop/release/support branches. Note, installers will still be built on commits to non develop/release/support branches, but installers will not be published. 