### PR TITLE
Tries moving spotbugs sast to semgrep because spotbugs end of life fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,6 @@ Static Application Security Testing (SAST) scanning and reports for a Gradle pro
 
 | Variable                	 | Default Value                                                        	 | Description                                                                                                                                                                               	 |
 |---------------------------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ASDF_JAVA_VERSION   	     | adoptopenjdk-17.0.1+12                                                 | The ASDF Java version.  	                                                                                                                                                                   |
 | SAST_DISABLED   	         |                                                                        | True to disable the jobs.  	                                                                                                                                                                |
 
 #### Reference URL
@@ -873,6 +872,7 @@ include:
 ## Change log
 
 #### [2.x.x] on Future Date... : Official stable release with many changes
+- Moves spotbugs sast to semgrep because spotbugs end of life for Gitlab for Java.
 - Fixes bug in Android Ext pipeline where couldn't add gradle extra flags. 
 - Various simple speed improvements to pipelines involving adding artifacts between jobs and moving jobs to different stages for parallelism. 
 - Updates several Docker images to smaller images for speed improvements. 

--- a/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
@@ -1,6 +1,4 @@
 semgrep-sast:
-  after_script:
-    - cat gl-sast-report.json
   artifacts:
     reports:
       dependency_scanning:

--- a/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
@@ -1,28 +1,6 @@
-spotbugs-sast:
-  # Work around for https://gitlab.com/gitlab-org/gitlab/-/issues/330733#note_746381737
-  before_script:
-    - chmod +x gradlew
-    - /bin/bash -c "source $HOME/.bashrc && asdf install java $ASDF_JAVA_VERSION && asdf global java $ASDF_JAVA_VERSION"
-  variables:
-    ASDF_JAVA_VERSION: adoptopenjdk-17.0.1+12
-    JAVA_PATH: /opt/asdf/shims/java
-  artifacts:
-    reports:
-      dependency_scanning:
-        - gl-sast-report.json
-    paths:
-      - gl-sast-report.json
-  rules:
-    - if: '$SAST_DISABLED =~ /true/i'
-      when: never
-    - if: $CI_COMMIT_TAG
-      when: never
-    - if: $CI_MERGE_REQUEST_IID
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
-
 semgrep-sast:
+  after_script:
+    - cat gl-sast-report.json
   artifacts:
     reports:
       dependency_scanning:

--- a/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
@@ -22,10 +22,27 @@ spotbugs-sast:
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
     - if: $CI_PIPELINE_SOURCE == "web"
 
+semgrep-sast:
+  artifacts:
+    reports:
+      dependency_scanning:
+        - gl-sast-report.json
+    paths:
+      - gl-sast-report.json
+  rules:
+    - if: '$SAST_DISABLED =~ /true/i'
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never
+    - if: $CI_MERGE_REQUEST_IID
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
+    - if: $CI_PIPELINE_SOURCE == "web"
+
 static_application_security_testing_validation:
   stage: report_processing
   image: "${IMAGE_PREFIX}python:3.11-rc-alpine"
-  needs: [ "spotbugs-sast" ]
+  needs: [ "semgrep-sast" ]
   allow_failure: true
   script:
     - ls

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -41,7 +41,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/feature/update-sast-from-spotbugs-to-semgrep-because-end-of-life/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
 

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -41,7 +41,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/feature/update-sast-from-spotbugs-to-semgrep-because-end-of-life/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/2.x.x/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
 


### PR DESCRIPTION
Spotbug end-of-life'd for Java for Gitlab SAST (See https://docs.gitlab.com/ee/user/application_security/sast/#end-of-supported-analyzers). This merge updates our Spotbugs SAST to Gitlab's new Semgrep for Java. 