### PR TITLE
Update junit report path to be more generic

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
@@ -29,9 +29,8 @@
     when: always
     expire_in: 1 days
     reports:
-      junit: [
-        ./**/build/outputs/androidTest-results/connected/TEST-*.xml,
-      ]
+      junit:
+        - "**/TEST-*.xml"
     paths:
       - "**/build/outputs/androidTest-results"
       - "**/build/reports/androidTests"


### PR DESCRIPTION
Updated Android instrumentented test job to have more generic path to junit test reports. This allows reports from flavored builds to be included.