### PR TITLE
CRAP integration improvements and misc. visualize coverage tweak

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
@@ -56,6 +56,7 @@ pages:
     - python3 create_aggregate_license_page.py
     - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/test/html/* public/coverage
     - test -e $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/ && cp -R $ROOT_PROJECT_DIR/build/reports/jacoco/jacocoAggregatedReport/html/* public/coverage
+    - test -e $ROOT_PROJECT_DIR/build/aggregate/html/ && cp -R $ROOT_PROJECT_DIR/build/aggregate/html/* public/coverage
     - test -e $ROOT_PROJECT_DIR/build/reports/dependency-license && cp -R $ROOT_PROJECT_DIR/build/reports/dependency-license/* public/dependency-licenses
     - test -e gl-dependency-scanning-report.html && cp gl-dependency-scanning-report.html public/dependency-vulnerabilities
     - test -e gl-sast-report.html && cp gl-sast-report.html public/source-vulnerabilities

--- a/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/Test.yml
@@ -37,8 +37,8 @@ visualize_test_coverage:
     - echo $JACOCO_XML_LOCATION
     - echo $JACOCO_HTML_LOCATION
     # GitLab CI "exist" rule doesn't account for artifacts so we need to check manually
-    - test -e $JACOCO_XML_LOCATION || exit 0
-    - test -e $JACOCO_HTML_LOCATION || exit 0
+    - test -e $JACOCO_XML_LOCATION || exit 1
+    - test -e $JACOCO_HTML_LOCATION || exit 1
     - mkdir -p build/reports/jacoco
     - 'python /opt/cover2cover.py $JACOCO_XML_LOCATION src/main/java > ./build/reports/jacoco/cobertura.xml'
     - 'python /opt/source2filename.py ./build/reports/jacoco/cobertura.xml'
@@ -61,3 +61,4 @@ visualize_test_coverage:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE == "web"
+  allow_failure: true


### PR DESCRIPTION
Copies artifacts generated by the CRAP plugin for use with the code coverage button and sets an appropriate exit value on failure.