### PR TITLE
Removing semgrep-sast duplicate artifact

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
@@ -3,8 +3,6 @@ semgrep-sast:
     reports:
       dependency_scanning:
         - gl-sast-report.json
-    paths:
-      - gl-sast-report.json
   rules:
     - if: '$SAST_DISABLED =~ /true/i'
       when: never

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -41,7 +41,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+  - remote: https://github.com/chesapeaketechnology/gitlab-templates/blob/DEVOPS-1146-fixing-security-reports-sast/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
 

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -41,7 +41,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
-  - remote: https://github.com/chesapeaketechnology/gitlab-templates/blob/DEVOPS-1146-fixing-security-reports-sast/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/refs/heads/DEVOPS-1146-fixing-security-reports-sast/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/3.x.x/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
 


### PR DESCRIPTION
Removing semgrep-sast duplicate artifact to fix the security report scanning issue:
- [Schema] property '/scan/type' is not one of: ["dependency_scanning"]