### PR TITLE
Bug/missing permissions in android instrumentation test

### DIFF
--- a/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
@@ -8,6 +8,7 @@
     ANDROID_EMULATOR_ADB_PORT: 5555
     APP_PACKAGE_NAMES_TO_FORCE_UNINSTALL: ""
   script:
+    - chmod +x gradlew
     - |
       for BUILD_TARGET in $BUILD_TARGETS
         do
@@ -21,7 +22,7 @@
           for app_package_name in $APP_PACKAGE_NAMES_TO_FORCE_UNINSTALL
             do
               echo "Attempting to uninstall $app_package_name"
-              adb uninstall "$app_package_name" || true; 
+              adb uninstall "$app_package_name" || true;
             done
           ./gradlew -Pci --console=plain $BUILD_TARGET
         done

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/4/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/bug/missing-permissions-in-android-instrumentation-test/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/4/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,5 +1,5 @@
 include:
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/bug/missing-permissions-in-android-instrumentation-test/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/4/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/4/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml


### PR DESCRIPTION
### Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file. ( "- Breaking change moving the chmod +x out directly into jobs. This includes deleting GradleWrapperSetup.yml and its .configure_gradle_wrapper job." already exists)
- [ ] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work. 
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch. 


