### PR TITLE
Allow parent pipelines to call Install4j jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This projec
 - Removed $PUBLISH_SNAPSHOT_GRADLE_FLAGS from publish_release_jar and also corrected Publish Jar README.md documented variables.
 - Updated Kaniko.yml from exit 1 to exit 0 if image already exists
 - Allowed publish_helm_chart to not require GPG signing.
+- Allowed Install4J pipelines (GradleInstall4JPipeline.yml) to be called from parent pipelines 
 
 ## [3.x.x] - 2025-04-25
 ### Added

--- a/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleInstall4JPipeline.yml
@@ -70,7 +70,7 @@ before_script:
       when: never
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH && $CI_COMMIT_TAG == null
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline")
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline"  || $CI_PIPELINE_SOURCE == "parent_pipeline")
 
 snapshot-installer:
   extends: .base-snapshot-installer
@@ -82,7 +82,7 @@ snapshot-installer:
   extends: .base-installer
   rules:
     # Only when manually invoked from the web UI and RELEASE has a non-empty value
-    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline") && $RELEASE
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline" || $CI_PIPELINE_SOURCE == "parent_pipeline") && $RELEASE
   variables:
     SNAPSHOT_FLAGS: ""
 


### PR DESCRIPTION
This change only adds a condition to two rules in `GradleInstall4JPipeline.yml`

Previously the rules for `.base-snapshot-installer` and `.base-release-installer` checked to see if the pipeline was manually invoked:

```
if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline" )
```

The condition now allows for parent pipelines to execute the job:

```
if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "pipeline"  || $CI_PIPELINE_SOURCE == "parent_pipeline")
```

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work. 
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch. 


