### PR TITLE
Allow all jobs and refenced jobs in GradleJavaPipeline.yml to be called from parent pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented in this file. This projec
 - Removed $PUBLISH_SNAPSHOT_GRADLE_FLAGS from publish_release_jar and also corrected Publish Jar README.md documented variables.
 - Updated Kaniko.yml from exit 1 to exit 0 if image already exists
 - Allowed publish_helm_chart to not require GPG signing.
-- Allowed Install4J pipelines (GradleInstall4JPipeline.yml) to be called from parent pipelines 
+- Allowed Install4J pipelines (GradleInstall4JPipeline.yml) to be called from parent pipelines
+- Allowed GradleJava pipelines and referenced pipelines to be called from parent pipelines
 
 ## [3.x.x] - 2025-04-25
 ### Added

--- a/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/Asciidoc.yml
@@ -21,4 +21,4 @@ generate_asciidoc:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/DependencyScanning.yml
@@ -25,7 +25,7 @@ gemnasium-maven-dependency_scanning:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 
 dependency_scanning_validation:
@@ -56,5 +56,5 @@ dependency_scanning_validation:
       when: always
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
       when: always
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
       when: always

--- a/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/LicenseScanning.yml
@@ -19,4 +19,4 @@ dependency_license_scanning:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
@@ -147,7 +147,7 @@ publish_release_jar:
     - if: $CI_COMMIT_TAG
       when: never
     # Invoked from the web UI and RELEASE has a non-empty value
-    - if: $CI_PIPELINE_SOURCE == "web" && $RELEASE
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline") && $RELEASE
     - if: $FORCE_PUBLISH_RELEASE_JAR == "true"
 
 roll_project_version:
@@ -164,6 +164,6 @@ roll_project_version:
   rules:
     - if: '$ROLL_PROJECT_VERSION_DISABLED =~ /true/i'
       when: never
-    - if: $CI_PIPELINE_SOURCE == "web" && ($RELEASE == "final" || $RELEASE == "FINAL")
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline") && ($RELEASE == "final" || $RELEASE == "FINAL")
     - if: '$FORCE_ROLL_PROJECT_VERSION =~ /true/i'
 

--- a/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/QualityReporting.yml
@@ -19,7 +19,7 @@ quality_check:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 quality_reporting:
   image: "${IMAGE_PREFIX}python:3.11-rc-alpine"
@@ -40,4 +40,4 @@ quality_reporting:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml
@@ -16,7 +16,7 @@ secret_detection:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 
 secret_detection_validation:
@@ -36,4 +36,4 @@ secret_detection_validation:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/StaticApplicationSecurityTesting.yml
@@ -16,7 +16,7 @@ semgrep-sast:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 static_application_security_testing_validation:
   stage: report_processing
@@ -46,5 +46,5 @@ static_application_security_testing_validation:
       when: always
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
       when: always
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
       when: always

--- a/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/Test.yml
@@ -33,7 +33,7 @@ test_java:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 visualize_test_coverage:
   stage: report_processing
@@ -65,5 +65,5 @@ visualize_test_coverage:
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
   allow_failure: true

--- a/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
+++ b/lib/gitlab/ci/templates/jobs/security/FortifyScanning.yml
@@ -30,4 +30,4 @@ fortify_scanning:
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -64,4 +64,4 @@ workflow:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: '$CI_COMMIT_BRANCH =~ $DEV_OR_RELEASE_REGEX'
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")

--- a/lib/gitlab/ci/templates/pipeline/GradlePluginReleasePipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradlePluginReleasePipeline.yml
@@ -42,14 +42,14 @@ test_java:
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline")
 
 pages:
   stage: deploy
   rules:
     - if: $PAGES_DISABLED
       when: never
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == 'web' && $RELEASE == 'true'
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline") && $RELEASE == 'true'
   script:
     - chmod +x gradlew
     - rm -rf public
@@ -64,7 +64,7 @@ doRelease:
   rules:
     - if: $DO_RELEASE_DISABLED
       when: never
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == 'web' && $RELEASE == 'true'
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "parent_pipeline" || $CI_PIPELINE_SOURCE == "pipeline") && $RELEASE == 'true'
   script:
     - chmod +x gradlew
     - ./gradlew -Prelease doRelease


### PR DESCRIPTION
### Checklist

- [X] I have performed a self-review of my code.
- [X] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [X] My changes generate no new warnings.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [X] I have added notes to the CHANGELOG.md file.
- [X] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [X] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work. 
- [X] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch. 


