### PR TITLE
Update DeployApkRelease to retire the files.upload API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [5] - on future date... somewhat unreleased but promises to have a new 5 be created for any breaking change
 ### Changed
+- deployApkRelease has been updated to retire the files.upload API. It has been replaced by files.getUploadURLExternal and files.completeUploadExternal.
 - Added logic to set RELEASE_FLAGS to GradleInstall4JPipeline.yml to support Build Support Plugin's custom repo publishing for both snapshot and release repos. 
 - Added variable SKIP_PUBLISH_TESTS: "true" to publish_snapshot_jar and publish_release_jar
 - Defaulting `VISUALIZE_TEST_COVERAGE_DISABLED` to `true` so that `visualize_test_coverage` job is effectively opt-in.

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -233,7 +233,8 @@ deployArtifactRelease:
         echo $DEPLOY_APK_NAME
         ls -la app/build/outputs/apk
         ls app/build/outputs/apk/release
-        apk_file=$(find $DEPLOY_APK_PATH -name *$DEPLOY_APK_NAME*)
+        # Find only .apk files (not .dm files)
+        apk_file=$(find $DEPLOY_APK_PATH -name "*$DEPLOY_APK_NAME*.apk" -type f | head -n 1)
         echo "Found APK file: $apk_file"
         
         if [ ! -f "$apk_file" ]; then

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -219,28 +219,27 @@ deployArtifactRelease:
         echo "No publish command found"
       fi
 
-deployApkDebug:
+# Template job 
+.deployApk:
   stage: deploy
-  rules: *debug_rules
-  allow_failure: true
   script:
     - if [ -z "${APK_SLACK_CHANNEL_ACCESS_TOKEN}" ]; then echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ACCESS_TOKEN'"; fi
     - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ID is set to '$APK_SLACK_CHANNEL_ID'"; fi
-    - if [ -z "${DEPLOY_DEBUG_APK_SLACK_MESSAGE}" ]; then echo "DEPLOY_DEBUG_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "DEPLOY_DEBUG_APK_SLACK_MESSAGE is set to '$DEPLOY_DEBUG_APK_SLACK_MESSAGE'"; fi
+    - if [ -z "${DEPLOY_APK_SLACK_MESSAGE}" ]; then echo "DEPLOY_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "DEPLOY_APK_SLACK_MESSAGE is set to '$DEPLOY_APK_SLACK_MESSAGE'"; fi
     - |
-      for DEPLOY_DEBUG_APK_NAME in $DEPLOY_DEBUG_APK_NAMES
+      for DEPLOY_APK_NAME in $DEPLOY_APK_NAMES
       do
-        debug_apk_file=$(find $DEPLOY_DEBUG_APK_PATH -name *$DEPLOY_DEBUG_APK_NAME*)
-        echo "Found debug APK file: $debug_apk_file"
+        apk_file=$(find $DEPLOY_APK_PATH -name *$DEPLOY_APK_NAME*)
+        echo "Found APK file: $apk_file"
         
-        if [ ! -f "$debug_apk_file" ]; then
-          echo "Error: APK file not found at $debug_apk_file"
+        if [ ! -f "$apk_file" ]; then
+          echo "Error: APK file not found at $apk_file"
           continue
         fi
         
         # Get file size and name for the upload
-        file_size=$(stat -f%z "$debug_apk_file" 2>/dev/null || stat -c%s "$debug_apk_file" 2>/dev/null)
-        file_name=$(basename "$debug_apk_file")
+        file_size=$(stat -f%z "$apk_file" 2>/dev/null || stat -c%s "$apk_file" 2>/dev/null)
+        file_name=$(basename "$apk_file")
         
         echo "Uploading $file_name (${file_size} bytes) to Slack..."
         
@@ -270,7 +269,7 @@ deployApkDebug:
         echo "Step 2: Uploading file to external URL..."
         file_upload_response=$(curl -s -w "%{http_code}" -o /dev/null \
           -X POST \
-          --data-binary "@$debug_apk_file" \
+          --data-binary "@$apk_file" \
           "$upload_url")
         
         if [ "$file_upload_response" -ne 200 ]; then
@@ -285,7 +284,7 @@ deployApkDebug:
         complete_response=$(curl -s \
           -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
           -H "Content-Type: application/json" \
-          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_DEBUG_APK_SLACK_MESSAGE\"}" \
+          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_APK_SLACK_MESSAGE\"}" \
           https://slack.com/api/files.completeUploadExternal)
         
         echo "Complete upload response: $complete_response"
@@ -302,87 +301,22 @@ deployApkDebug:
       done
   cache: {}
 
+deployApkDebug:
+  extends: .deployApk
+  rules: *debug_rules
+  allow_failure: true
+  variables:
+    DEPLOY_APK_PATH: $DEPLOY_DEBUG_APK_PATH
+    DEPLOY_APK_NAMES: $DEPLOY_DEBUG_APK_NAMES
+    DEPLOY_APK_SLACK_MESSAGE: $DEPLOY_DEBUG_APK_SLACK_MESSAGE
+
 deployApkRelease:
-  stage: deploy
+  extends: .deployApk
   rules: *release_rules
-  script:
-    - if [ -z "${APK_SLACK_CHANNEL_ACCESS_TOKEN}" ]; then echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ACCESS_TOKEN'"; fi
-    - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ID'"; fi
-    - if [ -z "${DEPLOY_RELEASE_APK_SLACK_MESSAGE}" ]; then echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is set to '$DEPLOY_RELEASE_APK_SLACK_MESSAGE'"; fi
-    - |
-      for DEPLOY_RELEASE_APK_NAME in $DEPLOY_RELEASE_APK_NAMES
-      do
-        debug_apk_file=$(find $DEPLOY_DEBUG_APK_PATH -name *$DEPLOY_RELEASE_APK_NAME*)
-        echo "Found debug APK file: $debug_apk_file"
-        
-        if [ ! -f "$debug_apk_file" ]; then
-          echo "Error: APK file not found at $debug_apk_file"
-          continue
-        fi
-        
-        # Get file size and name for the upload
-        file_size=$(stat -f%z "$debug_apk_file" 2>/dev/null || stat -c%s "$debug_apk_file" 2>/dev/null)
-        file_name=$(basename "$debug_apk_file")
-        
-        echo "Uploading $file_name (${file_size} bytes) to Slack..."
-        
-        # Step 1: Get upload URL using files.getUploadURLExternal (FORM DATA - not JSON!)
-        echo "Step 1: Getting upload URL..."
-        upload_response=$(curl -s \
-          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
-          -F "filename=$file_name" \
-          -F "length=$file_size" \
-          https://slack.com/api/files.getUploadURLExternal)
-        
-        echo "Upload URL response: $upload_response"
-        
-        # Parse the response to extract upload_url and file_id
-        upload_url=$(echo "$upload_response" | grep -o '"upload_url":"[^"]*"' | cut -d'"' -f4 | sed 's/\\//g')
-        file_id=$(echo "$upload_response" | grep -o '"file_id":"[^"]*"' | cut -d'"' -f4)
-        upload_ok=$(echo "$upload_response" | grep -o '"ok":[^,}]*' | cut -d':' -f2)
-        
-        if [ "$upload_ok" != "true" ]; then
-          echo "Error getting upload URL: $upload_response"
-          continue
-        fi
-        
-        echo "Got upload URL and file_id: $file_id"
-        
-        # Step 2: Upload the file to the provided URL
-        echo "Step 2: Uploading file to external URL..."
-        file_upload_response=$(curl -s -w "%{http_code}" -o /dev/null \
-          -X POST \
-          --data-binary "@$debug_apk_file" \
-          "$upload_url")
-        
-        if [ "$file_upload_response" -ne 200 ]; then
-          echo "File upload failed with HTTP status: $file_upload_response"
-          continue
-        fi
-        
-        echo "File uploaded successfully (HTTP $file_upload_response)"
-        
-        # Step 3: Complete the upload using files.completeUploadExternal
-        echo "Step 3: Completing upload..."
-        complete_response=$(curl -s \
-          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
-          -H "Content-Type: application/json" \
-          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_DEBUG_APK_SLACK_MESSAGE\"}" \
-          https://slack.com/api/files.completeUploadExternal)
-        
-        echo "Complete upload response: $complete_response"
-        
-        # Check if the completion was successful
-        complete_ok=$(echo $complete_response | grep -o '"ok":[^,}]*' | cut -d':' -f2)
-        
-        if [ "$complete_ok" = "true" ]; then
-          echo "Successfully uploaded $file_name to Slack!"
-        else
-          echo "Error completing upload: $complete_response"
-        fi
-        
-      done
-  cache: {}
+  variables:
+    DEPLOY_APK_PATH: $DEPLOY_RELEASE_APK_PATH
+    DEPLOY_APK_NAMES: $DEPLOY_RELEASE_APK_NAMES
+    DEPLOY_APK_SLACK_MESSAGE: $DEPLOY_RELEASE_APK_SLACK_MESSAGE
 
 combineCoverageReports:
   stage: report_processing

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -310,9 +310,9 @@ deployApkRelease:
     - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ID'"; fi
     - if [ -z "${DEPLOY_RELEASE_APK_SLACK_MESSAGE}" ]; then echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is set to '$DEPLOY_RELEASE_APK_SLACK_MESSAGE'"; fi
     - |
-      for DEPLOY_DEBUG_APK_NAME in $DEPLOY_DEBUG_APK_NAMES
+      for DEPLOY_RELEASE_APK_NAME in $DEPLOY_RELEASE_APK_NAMES
       do
-        debug_apk_file=$(find $DEPLOY_DEBUG_APK_PATH -name *$DEPLOY_DEBUG_APK_NAME*)
+        debug_apk_file=$(find $DEPLOY_DEBUG_APK_PATH -name *$DEPLOY_RELEASE_APK_NAME*)
         echo "Found debug APK file: $debug_apk_file"
         
         if [ ! -f "$debug_apk_file" ]; then

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -229,11 +229,7 @@ deployArtifactRelease:
     - |
       for DEPLOY_APK_NAME in $DEPLOY_APK_NAMES
       do
-        echo $DEPLOY_APK_PATH
-        echo $DEPLOY_APK_NAME
-        ls -la app/build/outputs/apk
-        ls app/build/outputs/apk/release
-        # Find only .apk files (not .dm files)
+        # # Find only .apk files (not .dm files)
         apk_file=$(find $DEPLOY_APK_PATH -name "*$DEPLOY_APK_NAME*.apk" -type f | head -n 1)
         echo "Found APK file: $apk_file"
         

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -310,17 +310,78 @@ deployApkRelease:
     - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ID'"; fi
     - if [ -z "${DEPLOY_RELEASE_APK_SLACK_MESSAGE}" ]; then echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "$DEPLOY_RELEASE_APK_SLACK_MESSAGE is set to '$DEPLOY_RELEASE_APK_SLACK_MESSAGE'"; fi
     - |
-      for DEPLOY_RELEASE_APK_NAME in $DEPLOY_RELEASE_APK_NAMES
-        do
-          release_apk_file=$(find $DEPLOY_RELEASE_APK_PATH -name *$DEPLOY_RELEASE_APK_NAME*)
-          echo "found release apk file $release_apk_file"
-          curl \
-            -F token="${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
-            -F channels="${APK_SLACK_CHANNEL_ID}" \
-            -F initial_comment="$DEPLOY_RELEASE_APK_SLACK_MESSAGE" \
-            -F "file=@$release_apk_file" \
-            https://slack.com/api/files.upload
-        done
+      for DEPLOY_DEBUG_APK_NAME in $DEPLOY_DEBUG_APK_NAMES
+      do
+        debug_apk_file=$(find $DEPLOY_DEBUG_APK_PATH -name *$DEPLOY_DEBUG_APK_NAME*)
+        echo "Found debug APK file: $debug_apk_file"
+        
+        if [ ! -f "$debug_apk_file" ]; then
+          echo "Error: APK file not found at $debug_apk_file"
+          continue
+        fi
+        
+        # Get file size and name for the upload
+        file_size=$(stat -f%z "$debug_apk_file" 2>/dev/null || stat -c%s "$debug_apk_file" 2>/dev/null)
+        file_name=$(basename "$debug_apk_file")
+        
+        echo "Uploading $file_name (${file_size} bytes) to Slack..."
+        
+        # Step 1: Get upload URL using files.getUploadURLExternal (FORM DATA - not JSON!)
+        echo "Step 1: Getting upload URL..."
+        upload_response=$(curl -s \
+          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
+          -F "filename=$file_name" \
+          -F "length=$file_size" \
+          https://slack.com/api/files.getUploadURLExternal)
+        
+        echo "Upload URL response: $upload_response"
+        
+        # Parse the response to extract upload_url and file_id
+        upload_url=$(echo "$upload_response" | grep -o '"upload_url":"[^"]*"' | cut -d'"' -f4 | sed 's/\\//g')
+        file_id=$(echo "$upload_response" | grep -o '"file_id":"[^"]*"' | cut -d'"' -f4)
+        upload_ok=$(echo "$upload_response" | grep -o '"ok":[^,}]*' | cut -d':' -f2)
+        
+        if [ "$upload_ok" != "true" ]; then
+          echo "Error getting upload URL: $upload_response"
+          continue
+        fi
+        
+        echo "Got upload URL and file_id: $file_id"
+        
+        # Step 2: Upload the file to the provided URL
+        echo "Step 2: Uploading file to external URL..."
+        file_upload_response=$(curl -s -w "%{http_code}" -o /dev/null \
+          -X POST \
+          --data-binary "@$debug_apk_file" \
+          "$upload_url")
+        
+        if [ "$file_upload_response" -ne 200 ]; then
+          echo "File upload failed with HTTP status: $file_upload_response"
+          continue
+        fi
+        
+        echo "File uploaded successfully (HTTP $file_upload_response)"
+        
+        # Step 3: Complete the upload using files.completeUploadExternal
+        echo "Step 3: Completing upload..."
+        complete_response=$(curl -s \
+          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_DEBUG_APK_SLACK_MESSAGE\"}" \
+          https://slack.com/api/files.completeUploadExternal)
+        
+        echo "Complete upload response: $complete_response"
+        
+        # Check if the completion was successful
+        complete_ok=$(echo $complete_response | grep -o '"ok":[^,}]*' | cut -d':' -f2)
+        
+        if [ "$complete_ok" = "true" ]; then
+          echo "Successfully uploaded $file_name to Slack!"
+        else
+          echo "Error completing upload: $complete_response"
+        fi
+        
+      done
   cache: {}
 
 combineCoverageReports:

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -229,6 +229,10 @@ deployArtifactRelease:
     - |
       for DEPLOY_APK_NAME in $DEPLOY_APK_NAMES
       do
+        echo $DEPLOY_APK_PATH
+        echo $DEPLOY_APK_NAME
+        ls -la app/build/outputs/apk
+        ls app/build/outputs/apk/release
         apk_file=$(find $DEPLOY_APK_PATH -name *$DEPLOY_APK_NAME*)
         echo "Found APK file: $apk_file"
         


### PR DESCRIPTION
### Checklist

- [X] I have performed a self-review of my code.
- [X] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [X] My changes generate no new warnings.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [X] I have added notes to the CHANGELOG.md file.
- [X] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [X] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [X] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs. 
- [X] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



