### PR TITLE
Fixed Docker multi-platform job failing for both CTI and Foundation t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. This projec
 - Moved a few echo '' to "" so variables like $GRADLE_TEST_FLAGS actually output since helpful for debugging.  
 
 ### Fixed 
+- Docker multi-platform job failing for both CTI and Foundation templates.
 - Gradle Plugin Release Pipeline's default image of openjdk:8-jdk-slim disappeared so replaced with debian-based eclipse-temurin:11-jdk. 
 - Moved jacoco2cobertura from 1.0.7 to 1.0.11 since 1.0.7 was removed from Gitlab's Docker registry and is causing the visualize_test_coverage and visualizeTestCoverage Gitlab job to fail.
 - Adds chmod +x back to gemnasium-maven-dependency_scanning and semgrep-sast to fix "permission denied" regression issue. 

--- a/README.md
+++ b/README.md
@@ -815,9 +815,9 @@ This is useful when you want to support multiple platforms with one image refere
 ```yaml
 multiarch_manifest_publish:
   stage: publish
-  image: docker:24.0.5
+  image: docker:28.4.0
   services:
-    - docker:dind
+    - docker:28.4.0-dind
   variables:
     DOCKER_TLS_CERTDIR: ""
     AMD_IMAGE: ""

--- a/lib/gitlab/ci/templates/jobs/docker/multiarch_manifest_publish.yml
+++ b/lib/gitlab/ci/templates/jobs/docker/multiarch_manifest_publish.yml
@@ -34,9 +34,9 @@
 
 .multiarch_manifest_publish:
   stage: publish
-  image: docker:24.0.5
+  image: docker:28.4.0
   services:
-    - docker:dind
+    - docker:28.4.0-dind
   variables:
     DOCKER_TLS_CERTDIR: ""
     AMD_IMAGE: ""


### PR DESCRIPTION
…emplates by setting job's image and service's dind image to the same fixed docker version 28.4.0.

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs. 
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



