### PR TITLE
Replace Cobertura with JaCoCo now that gitlab supports it natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 - Dependency vulnerability scanning to Android pipeline. 
 ### Changed
+- Removed dependence on cobertura in favor of native jacoco test report processing.
 - deployApkRelease has been updated to retire the files.upload API. It has been replaced by files.getUploadURLExternal and files.completeUploadExternal.
 - Added logic to set RELEASE_FLAGS to GradleInstall4JPipeline.yml to support Build Support Plugin's custom repo publishing for both snapshot and release repos. 
 - Added variable SKIP_PUBLISH_TESTS: "true" to publish_snapshot_jar and publish_release_jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 - Dependency vulnerability scanning to Android pipeline. 
 ### Changed
-- Removed dependence on cobertura in favor of native jacoco test report processing.
+- Removed dependence on cobertura in favor of native jacoco test report processing in Gradle and Android jobs.
 - deployApkRelease has been updated to retire the files.upload API. It has been replaced by files.getUploadURLExternal and files.completeUploadExternal.
 - Added logic to set RELEASE_FLAGS to GradleInstall4JPipeline.yml to support Build Support Plugin's custom repo publishing for both snapshot and release repos. 
 - Added variable SKIP_PUBLISH_TESTS: "true" to publish_snapshot_jar and publish_release_jar

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ they are posted to a Slack channel.
 | BUILD_TARGET                       | &check       | Different for different jobs.  For different flavored Android builds can put multiple build targets (i.e., `BUILD_TARGET: "testFlavor1Debug testFlavor2Debug"`) | Determines what type of apk should be produced. Leave blank to produce a debug apk or anything, like 'true', to create a release apk.                    |
 | COMBINE_CODE_COVERAGE_DISABLED     | &check;      | "true"                                                                                                                                                          | Boolean on whether to run the combineCoverageReports Gitlab job. 	                                                                                       |
 | VISUALIZE_TEST_COVERAGE_DISABLED   | &check;      | "true"                                                                                                                                                          | Boolean on whether to visualize the jacoco code coverage report. 	                                                                                       |
+| JACOCO_OUTPUT_DIR                  | &check;      | `$PROJECT_DIR/build/reports/jacoco`                                                                                                                             | Jacoco output directory for the JACOCO_HTML_LOCATION and JACOCO_XML_LOCATION. 	                                                                          |
+| JACOCO_HTML_LOCATION               | &check;      | `$JACOCO_OUTPUT_DIR/index.html`                                                                                                                                 | Jacoco HTML file location used by Gitlab for things like calculating the test coverage percentage to display in merge requests. 	                        |
+| JACOCO_XML_LOCATION                | &check;      | `$JACOCO_OUTPUT_DIR/jacoco-report.xml`                                                                                                                          | Jacoco XML file location used for things like displaying a test coverage report. 	                                                                       |
 | PROJECT_DIR                 	      | &check;      | ./	                                                                                                                                                             | Used to specify file paths in the combineCoverageReports and visualizeCombinedTestCoverage jobs. 	                                                       |
 | MAVEN_DETECTION_DISABLED   	       | &check;      | "false"                                                                                                                                                         | True to disable dependency scanning.  	                                                                                                                  |
 | SAST_DISABLED   	                  | &check;      | "" (which evaluates to false so the SAST job is turned on by default)                                                                                           | True to disable SAST scanning.  	                                                                                                                        |
@@ -535,10 +538,11 @@ job.
 
 #### Customization
 
-| Variable          	       | Description                                            	 |
-|---------------------------|----------------------------------------------------------|
-| EXTRA_GRADLE_TEST_FLAGS 	 | Flags that will be appended to the gradle test command 	 |
-| EXTRA_GRADLE_TEST_FLAGS 	 | Flags that will be appended to the gradle test command 	 |
+| Variable          	       | Description                                            	                                                                        |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| JACOCO_OUTPUT_DIR 	 | Jacoco output directory for the JACOCO_HTML_LOCATION and JACOCO_XML_LOCATION 	                                                  |
+| JACOCO_HTML_LOCATION 	 | Jacoco HTML file location used by Gitlab for things like calculating the test coverage percentage to display in merge requests	 |
+| JACOCO_XML_LOCATION 	 | Jacoco XML file location used for things like displaying a test coverage report	                                                |
 
 #### Reference URL
 
@@ -853,7 +857,7 @@ multiarch_manifest_publish:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-
+```
 
 ---
 ### JIB Docker Image Publishing(job)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ branch match the below DEV_OR_RELEASE_REGEX variable.
 | TASK_ARGUMENTS                                     |              |                                                                                     | Additional command line arguments and gradle tasks for this build. ex: \"-Pforce -x updateReleaseVersion\" These tasks will run on every job downstream.                                                     |
 | RELEASE                 	                          | &check;      | 	                                                                                   | The name that will be appended to release build artifacts. By default an release candidate will be created from this unless the value "final" is used. 	                                                     |
 | GRADLE_TEST_FLAGS                 	                | &check;      | -s --no-daemon -PnoMavenLocal --refresh-dependencies --console=plain 	              | Gradle flags that will be appended when running the Test Gradle task(s). 	                                                                                                                                   |
+| EXTRA_GRADLE_TEST_FLAGS                 	          |              | ""	                                                                                 | Flags that will be appended to the GRADLE_TEST_FLAGS. 	                                                                                                                                                      |
 | QUALITY_CHECK_GRADLE_TASKS                 	       | &check;      | pmdMain violations -x build -x test	                                                | The gradle tasks used to run the Quality Check Gradle task(s). 	                                                                                                                                             |
 | QUALITY_CHECK_DISABLED                 	           | &check;      | true	                                                                               | Boolean on whether to run the Quality Check Gitlab job(s).  	                                                                                                                                                |
 | DEPENDENCY_LICENSE_SCANNING_DISABLED               | &check;      | true	                                                                               | Boolean on whether to run the Dependency License Scan Gitlab job(s).  	                                                                                                                                      |
@@ -536,6 +537,7 @@ job.
 
 | Variable          	       | Description                                            	 |
 |---------------------------|----------------------------------------------------------|
+| EXTRA_GRADLE_TEST_FLAGS 	 | Flags that will be appended to the gradle test command 	 |
 | EXTRA_GRADLE_TEST_FLAGS 	 | Flags that will be appended to the gradle test command 	 |
 
 #### Reference URL

--- a/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/Test.yml
@@ -37,24 +37,20 @@ test_java:
 
 visualize_test_coverage:
   stage: report_processing
-  image: registry.gitlab.com/haynes/jacoco2cobertura:1.0.11
   script:
     - echo $JACOCO_XML_LOCATION
     - echo $JACOCO_HTML_LOCATION
     # GitLab CI "exist" rule doesn't account for artifacts so we need to check manually
     - test -e $JACOCO_XML_LOCATION || exit 1
     - test -e $JACOCO_HTML_LOCATION || exit 1
-    - mkdir -p build/reports/jacoco
-    - 'python /opt/cover2cover.py $JACOCO_XML_LOCATION src/main/java > ./build/reports/jacoco/cobertura.xml'
-    - 'python /opt/source2filename.py ./build/reports/jacoco/cobertura.xml'
     - cat $JACOCO_HTML_LOCATION | grep -o 'Total[^%]*%'
   coverage: '/Total.*?([0-9]{1,3})%/'
   needs: [ "test_java" ]
   artifacts:
     reports:
       coverage_report:
-        coverage_format: cobertura
-        path: "**/cobertura.xml"
+        coverage_format: jacoco
+        path: "**/build/reports/jacoco/test/jacocoTestReport.xml"
   rules:
     - if: '$TEST_JAVA_DISABLED =~ /true/i'
       when: never

--- a/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/Test.yml
@@ -2,9 +2,9 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/references/gradle/GradleJavaBase.yml
 
 variables:
-  JACOCO_OUTPUT_DIR: ./reports/jacoco
-  JACOCO_HTML_LOCATION: $JACOCO_OUTPUT_DIR/index.html
-  JACOCO_XML_LOCATION: $JACOCO_OUTPUT_DIR/jacoco-report.xml
+  JACOCO_OUTPUT_DIR: ./build/reports/jacoco/test
+  JACOCO_HTML_LOCATION: $JACOCO_OUTPUT_DIR/html/index.html
+  JACOCO_XML_LOCATION: $JACOCO_OUTPUT_DIR/jacocoTestReport.xml
 
 test_java:
   extends: .gradle_java_base
@@ -18,7 +18,6 @@ test_java:
     when: always
     paths:
       - $JACOCO_OUTPUT_DIR
-      - ./build/reports/jacoco/
       - "**/build/reports/tests"
     reports:
       junit:
@@ -50,7 +49,7 @@ visualize_test_coverage:
     reports:
       coverage_report:
         coverage_format: jacoco
-        path: "**/build/reports/jacoco/test/jacocoTestReport.xml"
+        path: "$JACOCO_XML_LOCATION"
   rules:
     - if: '$TEST_JAVA_DISABLED =~ /true/i'
       when: never

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -380,22 +380,18 @@ combineCoverageReports:
 visualizeTestCoverage:
   stage: report_processing
   needs: [combineCoverageReports]
-  image: registry.gitlab.com/haynes/jacoco2cobertura:1.0.11
   script:
     - echo $JACOCO_HTML_LOCATION
     - echo $JACOCO_XML_LOCATION
     - test -e $JACOCO_XML_LOCATION || { echo "JaCoCo XML report not found!"; exit 1; }
     - test -e $JACOCO_HTML_LOCATION || { echo "JaCoCo HTML report not found!"; exit 1; }
-    - mkdir -p build/reports/jacoco
-    - python /opt/cover2cover.py $JACOCO_XML_LOCATION $PROJECT_DIR/src/main/java > $PROJECT_DIR/build/reports/jacoco/cobertura.xml
-    - python /opt/source2filename.py $PROJECT_DIR/build/reports/jacoco/cobertura.xml
     - cat $JACOCO_HTML_LOCATION | grep -o 'Total[^%]*%'
   coverage: '/Total.*?([0-9]{1,3})%/'
   artifacts:
     reports:
       coverage_report:
-        coverage_format: cobertura
-        path: "**/cobertura.xml"
+        coverage_format: jacoco
+        path: "**/build/reports/jacoco/test/jacocoTestReport.xml"
   rules:
     - if: '$VISUALIZE_TEST_COVERAGE_DISABLED =~ /true/i'
       when: never

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -391,7 +391,7 @@ visualizeTestCoverage:
     reports:
       coverage_report:
         coverage_format: jacoco
-        path: "**/build/reports/jacoco/test/jacocoTestReport.xml"
+        path: "$JACOCO_XML_LOCATION"
   rules:
     - if: '$VISUALIZE_TEST_COVERAGE_DISABLED =~ /true/i'
       when: never

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -37,7 +37,7 @@ cache:
   policy: pull-push
 
 include:
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/DEVOPS-1627-update_template/lib/gitlab/ci/templates/jobs/gradle/Test.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml

--- a/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
+++ b/lib/gitlab/ci/templates/pipeline/GradleJavaPipeline.yml
@@ -37,7 +37,7 @@ cache:
   policy: pull-push
 
 include:
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/DEVOPS-1627-update_template/lib/gitlab/ci/templates/jobs/gradle/Test.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/Test.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/PublishJar.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/PublishPages.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/SecretDetection.yml


### PR DESCRIPTION
### Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs. 
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



