### PR TITLE
Add java gradle atak offline template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [5] - on future date... somewhat unreleased but promises to have a new 5 be created for any breaking change
 ### Added
+- Java Gradle ATAK Offline template.
 - Dependency vulnerability scanning to Android pipeline. 
 ### Changed
 - Removed dependence on cobertura in favor of native jacoco test report processing in Gradle and Android jobs.

--- a/lib/gitlab/ci/templates/jobs/gradle/java-gradle-atak-offline.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/java-gradle-atak-offline.yml
@@ -1,0 +1,86 @@
+# Offline ATAK CI Template
+# This template provides build and test jobs for ATAK plugins using ATAK dependencies hosted on
+# CTI's artifactory. This allows users to build and test plugins on CTI's Gitlab pipelines.
+# This template currently does not support building release ATAK plugin APKs as that requires
+# the TAK.gov Gitlab CI runner to perform signing.
+#
+# This template is created with the intentionality that it can be simply included and work with
+# any ATAK plugin that follows the same template as HelloWorld on the official TAK.gov Gitlab.
+#
+# Required CI Variables:
+#   - ARTIFACT_REPO_USERNAME: Artifactory username
+#   - ARTIFACT_REPO_PASSWORD: Artifactory password
+
+# Setup ATAK dependencies before running jobs
+.template-gradle-atak-repos:
+  variables:
+    IMAGE_PREFIX: "harbor.ctic-dev.com/platform-engineering/"
+    DEFAULT_IMAGE: "theimpulson/gitlab-ci-android:android-35-jdk-17"
+    ATAK_DEV_REPO_URL: "https://artifactory.ctic-dev.com/artifactory/maven-development-local"
+    ATAK_TOOL_REPO_URL: "https://artifactory.ctic-dev.com/artifactory/maven-tooling-local"
+    GIT_DEPTH: 1
+    GIT_SUBMODULE_STRATEGY: recursive
+    STANDARD_GRADLE_FLAGS: '-s --no-daemon -PnoMavenLocal --refresh-dependencies --console=plain'
+    EXTRA_GRADLE_FLAGS: "--init-script .gradle/init.d/ci-atak-repos.gradle"
+    GRADLE_FLAGS: "$STANDARD_GRADLE_FLAGS $EXTRA_GRADLE_FLAGS"
+  image: ${IMAGE_PREFIX}$DEFAULT_IMAGE
+  interruptible: true
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .gradle/wrapper
+      - .gradle/caches
+  script:
+    - mkdir -p .gradle/init.d
+    - |
+      cat > .gradle/init.d/ci-atak-repos.gradle <<'EOF'
+      allprojects {
+        buildscript {
+            ext.taktoolrepoUrl = System.getenv("ATAK_TOOL_REPO_URL")
+            ext.takrepoUrl = System.getenv("ATAK_DEV_REPO_URL")
+            ext.takrepoUser = System.getenv("ARTIFACT_REPO_USERNAME")
+            ext.takrepoPassword = System.getenv("ARTIFACT_REPO_PASSWORD")
+            repositories {
+                maven {
+                    url takrepoUrl
+                    credentials {
+                        username = System.getenv("ARTIFACT_REPO_USERNAME")
+                        password = System.getenv("ARTIFACT_REPO_PASSWORD")
+                    }
+                }
+                maven {
+                    url taktoolrepoUrl
+                    credentials {
+                        username = System.getenv("ARTIFACT_REPO_USERNAME")
+                        password = System.getenv("ARTIFACT_REPO_PASSWORD")
+                    }
+                }
+            }
+        }
+      }
+      EOF
+    - |
+      cat > local.properties <<EOF
+      takrepo.url=${ATAK_DEV_REPO_URL}
+      takrepo.user=${ARTIFACT_REPO_USERNAME}
+      takrepo.password=${ARTIFACT_REPO_PASSWORD}
+      EOF
+
+.template-gradle-assemble-plugin:
+  extends: .template-gradle-atak-repos
+  stage: build
+  interruptible: true
+  script:
+    - !reference [.template-gradle-atak-repos, script] #setup atak repos
+    - ./gradlew $GRADLE_FLAGS ${ASSEMBLE_GRADLE_TASK} #perform task
+  artifacts:
+    expire_in: 336h
+    paths:
+      - app/build/outputs/apk
+
+.template-gradle-test-plugin:
+  extends: .template-gradle-atak-repos
+  stage: test
+  script:
+    - !reference [.template-gradle-atak-repos, script] #setup atak repos
+    - ./gradlew $GRADLE_FLAGS ${TEST_GRADLE_TASK} #perform task


### PR DESCRIPTION
### Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs. 
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



