### PR TITLE
Refactoring Slack APK Deployment Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This projec
 - Deleting Cargo jobs and pipeline. They have been moved to Gitlab under: https://gitlab.ctic-dev.com/engineering/foundation/ci-pipeline-templates/-/blob/master/ci-templates/cargo.yml?ref_type=heads
 - deployApkDebug has been updated to retire the files.upload API. It has been replaced by files.getUploadURLExternal and files.completeUploadExternal.
 - Moved a few echo '' to "" so variables like $GRADLE_TEST_FLAGS actually output since helpful for debugging.  
+- `.deployApk` has been moved from `AndroidTemplate.yml` to a stand-alone template `SlackAPKDeployment.yml`
 
 ### Fixed 
 - Docker multi-platform job failing for both CTI and Foundation templates.

--- a/lib/gitlab/ci/templates/jobs/gradle/SlackAPKDeployment.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/SlackAPKDeployment.yml
@@ -1,0 +1,111 @@
+variables:
+  DEPLOY_DEBUG_APK_SLACK_MESSAGE: ""
+  DEPLOY_DEBUG_APK_PATH: app/build/outputs/apk
+  DEPLOY_DEBUG_APK_NAMES: ""
+  DEPLOY_RELEASE_APK_SLACK_MESSAGE: ""
+  DEPLOY_RELEASE_APK_PATH: app/build/outputs/apk
+  DEPLOY_RELEASE_APK_NAMES: ""
+  APK_SLACK_CHANNEL_ACCESS_TOKEN: ""
+  APK_SLACK_CHANNEL_ID: ""
+  ARTIFACT_SNAPSHOT_URL: ""
+  ARTIFACT_RELEASE_URL: ""
+  ARTIFACT_REPO_PASSWORD: ""
+  ARTIFACT_REPO_USERNAME: ""
+
+.deployApk:
+  stage: deploy
+  script:
+    - if [ -z "${APK_SLACK_CHANNEL_ACCESS_TOKEN}" ]; then echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ACCESS_TOKEN'"; fi
+    - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ID is set to '$APK_SLACK_CHANNEL_ID'"; fi
+    - if [ -z "${DEPLOY_APK_SLACK_MESSAGE}" ]; then echo "DEPLOY_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "DEPLOY_APK_SLACK_MESSAGE is set to '$DEPLOY_APK_SLACK_MESSAGE'"; fi
+    - |
+      for DEPLOY_APK_NAME in $DEPLOY_APK_NAMES
+      do
+        # Determine the search pattern based on whether DEPLOY_APK_NAME already contains .apk
+        if [[ "$DEPLOY_APK_NAME" == *.apk* ]]; then
+          # Already includes .apk extension, use as-is
+          search_pattern="*$DEPLOY_APK_NAME"
+        else
+          # Just a base name, add wildcard and .apk extension
+          search_pattern="*${DEPLOY_APK_NAME}*.apk"
+        fi
+
+        echo "Searching for APK with pattern: $search_pattern"
+
+        # Find the APK file, excluding baseline profile .dm files
+        apk_file=$(find "$DEPLOY_APK_PATH" -type f -name "$search_pattern" ! -name "*.dm" 2>/dev/null | head -n 1 | tr -d '\n')
+        echo "Found APK file: $apk_file"
+
+        # Validate the file exists
+        if [ -z "$apk_file" ] || [ ! -f "$apk_file" ]; then
+          echo "Error: No APK file found matching pattern '$search_pattern' in $DEPLOY_APK_PATH"
+          echo "Listing directory contents:"
+          ls -la "$DEPLOY_APK_PATH" 2>/dev/null || echo "Directory not found"
+          exit 1
+        fi
+
+        echo "✓ Success! APK file found: $apk_file"
+      
+        # Get file size and name for the upload
+        file_size=$(stat -f%z "$apk_file" 2>/dev/null || stat -c%s "$apk_file" 2>/dev/null)
+        file_name=$(basename "$apk_file")
+      
+        echo "Uploading $file_name (${file_size} bytes) to Slack..."
+      
+        # Step 1: Get upload URL using files.getUploadURLExternal (FORM DATA - not JSON!)
+        echo "Step 1: Getting upload URL..."
+        upload_response=$(curl -s \
+          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
+          -F "filename=$file_name" \
+          -F "length=$file_size" \
+          https://slack.com/api/files.getUploadURLExternal)
+      
+        echo "Upload URL response: $upload_response"
+      
+        # Parse the response to extract upload_url and file_id
+        upload_url=$(echo "$upload_response" | grep -o '"upload_url":"[^"]*"' | cut -d'"' -f4 | sed 's/\\//g')
+        file_id=$(echo "$upload_response" | grep -o '"file_id":"[^"]*"' | cut -d'"' -f4)
+        upload_ok=$(echo "$upload_response" | grep -o '"ok":[^,}]*' | cut -d':' -f2)
+      
+        if [ "$upload_ok" != "true" ]; then
+          echo "Error getting upload URL: $upload_response"
+          continue
+        fi
+      
+        echo "Got upload URL and file_id: $file_id"
+      
+        # Step 2: Upload the file to the provided URL
+        echo "Step 2: Uploading file to external URL..."
+        file_upload_response=$(curl -s -w "%{http_code}" -o /dev/null \
+          -X POST \
+          --data-binary "@$apk_file" \
+          "$upload_url")
+      
+        if [ "$file_upload_response" -ne 200 ]; then
+          echo "File upload failed with HTTP status: $file_upload_response"
+          continue
+        fi
+      
+        echo "File uploaded successfully (HTTP $file_upload_response)"
+      
+        # Step 3: Complete the upload using files.completeUploadExternal
+        echo "Step 3: Completing upload..."
+        complete_response=$(curl -s \
+          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
+          -H "Content-Type: application/json" \
+          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_APK_SLACK_MESSAGE\"}" \
+          https://slack.com/api/files.completeUploadExternal)
+      
+        echo "Complete upload response: $complete_response"
+      
+        # Check if the completion was successful
+        complete_ok=$(echo $complete_response | grep -o '"ok":[^,}]*' | cut -d':' -f2)
+      
+        if [ "$complete_ok" = "true" ]; then
+          echo "Successfully uploaded $file_name to Slack!"
+        else
+          echo "Error completing upload: $complete_response"
+        fi
+      
+      done
+  cache: { }

--- a/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
+++ b/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
@@ -1,10 +1,12 @@
 variables:
-  DEPLOY_DEBUG_APK_SLACK_MESSAGE: ""
+  DEPLOY_DEBUG_APK_SLACK_MESSAGE: "Hello Team! Here is the latest debug APK/AAR from branch `${CI_COMMIT_REF_NAME}`. It was triggered by: `${CI_PIPELINE_SOURCE}`."
   DEPLOY_DEBUG_APK_PATH: app/build/outputs/apk
-  DEPLOY_DEBUG_APK_NAMES: ""
-  DEPLOY_RELEASE_APK_SLACK_MESSAGE: ""
+  DEPLOY_DEBUG_AAR_PATH: app/build/outputs/aar
+  DEPLOY_DEBUG_APK_NAMES: yourdebugapkname
+  DEPLOY_RELEASE_APK_SLACK_MESSAGE: "Hello Team! Here is the latest release APK/AAR triggered by tag: `${CI_COMMIT_TAG}`"
   DEPLOY_RELEASE_APK_PATH: app/build/outputs/apk
-  DEPLOY_RELEASE_APK_NAMES: ""
+  DEPLOY_RELEASE_AAR_PATH: app/build/outputs/aar
+  DEPLOY_RELEASE_APK_NAMES: yourreleaseapkname
   APK_SLACK_CHANNEL_ACCESS_TOKEN: ""
   APK_SLACK_CHANNEL_ID: ""
   ARTIFACT_SNAPSHOT_URL: ""
@@ -12,6 +14,7 @@ variables:
   ARTIFACT_REPO_PASSWORD: ""
   ARTIFACT_REPO_USERNAME: ""
 
+# Template job
 .deployApk:
   stage: deploy
   script:
@@ -108,4 +111,4 @@ variables:
         fi
       
       done
-  cache: { }
+  cache: {}

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -3,7 +3,7 @@ include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
   # TODO: change to remote once SlackAPKDeployment.yml gets merged in
   #  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
-  - local: 'lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml'
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/f85e1786e06bc52dc45294f7e4ef9b2027c081fd/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,6 +1,9 @@
 include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
+  # TODO: change to remote once SlackAPKDeployment.yml gets merged in
+  #  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
+  - local: 'lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml'
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml
@@ -239,105 +242,6 @@ deployArtifactRelease:
         echo "No publish command found"
       fi
 
-# Template job 
-.deployApk:
-  stage: deploy
-  script:
-    - if [ -z "${APK_SLACK_CHANNEL_ACCESS_TOKEN}" ]; then echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ACCESS_TOKEN is set to '$APK_SLACK_CHANNEL_ACCESS_TOKEN'"; fi
-    - if [ -z "${APK_SLACK_CHANNEL_ID}" ]; then echo "APK_SLACK_CHANNEL_ID is unset so not pushing message to Slack"; else echo "APK_SLACK_CHANNEL_ID is set to '$APK_SLACK_CHANNEL_ID'"; fi
-    - if [ -z "${DEPLOY_APK_SLACK_MESSAGE}" ]; then echo "DEPLOY_APK_SLACK_MESSAGE is unset so will use empty message for Slack"; else echo "DEPLOY_APK_SLACK_MESSAGE is set to '$DEPLOY_APK_SLACK_MESSAGE'"; fi
-    - |
-      for DEPLOY_APK_NAME in $DEPLOY_APK_NAMES
-      do
-        # Determine the search pattern based on whether DEPLOY_APK_NAME already contains .apk
-        if [[ "$DEPLOY_APK_NAME" == *.apk* ]]; then
-          # Already includes .apk extension, use as-is
-          search_pattern="*$DEPLOY_APK_NAME"
-        else
-          # Just a base name, add wildcard and .apk extension
-          search_pattern="*${DEPLOY_APK_NAME}*.apk"
-        fi
-
-        echo "Searching for APK with pattern: $search_pattern"
-
-        # Find the APK file, excluding baseline profile .dm files
-        apk_file=$(find "$DEPLOY_APK_PATH" -type f -name "$search_pattern" ! -name "*.dm" 2>/dev/null | head -n 1 | tr -d '\n')
-        echo "Found APK file: $apk_file"
-
-        # Validate the file exists
-        if [ -z "$apk_file" ] || [ ! -f "$apk_file" ]; then
-          echo "Error: No APK file found matching pattern '$search_pattern' in $DEPLOY_APK_PATH"
-          echo "Listing directory contents:"
-          ls -la "$DEPLOY_APK_PATH" 2>/dev/null || echo "Directory not found"
-          exit 1
-        fi
-
-        echo "✓ Success! APK file found: $apk_file"
-        
-        # Get file size and name for the upload
-        file_size=$(stat -f%z "$apk_file" 2>/dev/null || stat -c%s "$apk_file" 2>/dev/null)
-        file_name=$(basename "$apk_file")
-        
-        echo "Uploading $file_name (${file_size} bytes) to Slack..."
-        
-        # Step 1: Get upload URL using files.getUploadURLExternal (FORM DATA - not JSON!)
-        echo "Step 1: Getting upload URL..."
-        upload_response=$(curl -s \
-          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
-          -F "filename=$file_name" \
-          -F "length=$file_size" \
-          https://slack.com/api/files.getUploadURLExternal)
-        
-        echo "Upload URL response: $upload_response"
-        
-        # Parse the response to extract upload_url and file_id
-        upload_url=$(echo "$upload_response" | grep -o '"upload_url":"[^"]*"' | cut -d'"' -f4 | sed 's/\\//g')
-        file_id=$(echo "$upload_response" | grep -o '"file_id":"[^"]*"' | cut -d'"' -f4)
-        upload_ok=$(echo "$upload_response" | grep -o '"ok":[^,}]*' | cut -d':' -f2)
-        
-        if [ "$upload_ok" != "true" ]; then
-          echo "Error getting upload URL: $upload_response"
-          continue
-        fi
-        
-        echo "Got upload URL and file_id: $file_id"
-        
-        # Step 2: Upload the file to the provided URL
-        echo "Step 2: Uploading file to external URL..."
-        file_upload_response=$(curl -s -w "%{http_code}" -o /dev/null \
-          -X POST \
-          --data-binary "@$apk_file" \
-          "$upload_url")
-        
-        if [ "$file_upload_response" -ne 200 ]; then
-          echo "File upload failed with HTTP status: $file_upload_response"
-          continue
-        fi
-        
-        echo "File uploaded successfully (HTTP $file_upload_response)"
-        
-        # Step 3: Complete the upload using files.completeUploadExternal
-        echo "Step 3: Completing upload..."
-        complete_response=$(curl -s \
-          -H "Authorization: Bearer ${APK_SLACK_CHANNEL_ACCESS_TOKEN}" \
-          -H "Content-Type: application/json" \
-          -d "{\"files\":[{\"id\":\"$file_id\",\"title\":\"$file_name\"}],\"channel_id\":\"${APK_SLACK_CHANNEL_ID}\",\"initial_comment\":\"$DEPLOY_APK_SLACK_MESSAGE\"}" \
-          https://slack.com/api/files.completeUploadExternal)
-        
-        echo "Complete upload response: $complete_response"
-        
-        # Check if the completion was successful
-        complete_ok=$(echo $complete_response | grep -o '"ok":[^,}]*' | cut -d':' -f2)
-        
-        if [ "$complete_ok" = "true" ]; then
-          echo "Successfully uploaded $file_name to Slack!"
-        else
-          echo "Error completing upload: $complete_response"
-        fi
-        
-      done
-  cache: {}
-
 deployApkDebug:
   extends: .deployApk
   rules: *debug_rules
@@ -379,7 +283,7 @@ combineCoverageReports:
 
 visualizeTestCoverage:
   stage: report_processing
-  needs: [combineCoverageReports]
+  needs: [ combineCoverageReports ]
   script:
     - echo $JACOCO_HTML_LOCATION
     - echo $JACOCO_XML_LOCATION


### PR DESCRIPTION
## Description

Creating a separate template for `.deployApk` so it can be used as a stand-alone task for publishing apks to slack.

Successful apk deployment with changes: https://cti-chat.slack.com/archives/C09DDLX07G8/p1768935956931579 , https://gitlab.ctic-dev.com/engineering/platform-engineering-golden-path-templates/gitlab-android-pipeline-example/-/jobs/406602

## Changes

<!-- List the main changes made in this merge request. -->
- Change 1: Adding `SlackAPKDeployment.yml` as a stand-alone template for deploying apks to slack
- Change 2: Integrating `SlackAPKDeployment.yml` into `AndroidTemplate.yml`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs.
- [x] Any global Gitlab variables are named distinctly so they have low-potential of conflicting with other global Gitlab variables (e.g., use "JAVA_GRADLE_ATAK_OFFLINE_IMAGE_PREFIX" instead of "IMAGE_PREFIX").
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



