### PR TITLE
Fix slack apk deployment pathing

### DIFF
--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,9 +1,7 @@
 include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
-  # TODO: change to remote once SlackAPKDeployment.yml gets merged in
-  #  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/f85e1786e06bc52dc45294f7e4ef9b2027c081fd/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml
   - template: Jobs/Dependency-Scanning.gitlab-ci.yml


### PR DESCRIPTION
## Description

This PR is for fixing imports in `AndroidTemplate.yml` once `SlackAPKDeployment.yml` gets merged in via https://github.com/chesapeaketechnology/gitlab-templates/pull/158

The changes were successful as seen: https://gitlab.ctic-dev.com/engineering/platform-engineering-golden-path-templates/gitlab-android-pipeline-example/-/jobs/406691 , and https://cti-chat.slack.com/archives/C09DDLX07G8/p1768939778180229
## Changes

<!-- List the main changes made in this merge request. -->
- Change 1: update remote `SlackAPKDeployment.yml` import within `AndroidTemplate.yml`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs.
- [x] Any global Gitlab variables are named distinctly so they have low-potential of conflicting with other global Gitlab variables (e.g., use "JAVA_GRADLE_ATAK_OFFLINE_IMAGE_PREFIX" instead of "IMAGE_PREFIX").
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



