### PR TITLE
cache Gradle build-cache and remove --refresh-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [5] - on future date... somewhat unreleased but promises to have a new 5 be created for any breaking change
 ### Added
+- Gradle CI cache path for build-cache directory.
 - Java Gradle ATAK Offline template jobs.
 - Dependency vulnerability scanning to Android pipeline. 
 
 ### Changed
+- Remove `--refresh-dependencies` from template build in `java-gradle-atak-offline.yml`.
 - Marked AndroidTemplateExt.yml as deprecated and for removal in release/6 since replaced by Java Gradle ATAK Offline template jobs.
 - Removed dependence on cobertura in favor of native jacoco test report processing in Gradle and Android jobs.
 - deployApkRelease has been updated to retire the files.upload API. It has been replaced by files.getUploadURLExternal and files.completeUploadExternal.

--- a/lib/gitlab/ci/templates/jobs/gradle/JavaGradleAtakOffline.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/JavaGradleAtakOffline.yml
@@ -9,7 +9,7 @@ variables:
 # Setup ATAK dependencies before running jobs
 .template-gradle-atak-repos:
   variables:
-    STANDARD_GRADLE_FLAGS: '-s --no-daemon -PnoMavenLocal --refresh-dependencies --console=plain'
+    STANDARD_GRADLE_FLAGS: '-s --no-daemon -PnoMavenLocal --console=plain'
     EXTRA_GRADLE_FLAGS: "--init-script .gradle/init.d/ci-atak-repos.gradle"
     GRADLE_PUBLISH_ARGS: >-
       -PartifactUsername=$ARTIFACT_REPO_USERNAME
@@ -21,9 +21,12 @@ variables:
     paths:
       - .gradle/wrapper
       - .gradle/caches
+      - .gradle/build-cache-*
   script:
     # Setup gradlew permissions in case it is not already executable
     - chmod +x gradlew
+    - export GRADLE_USER_HOME=$CI_PROJECT_DIR/.gradle
+    - mkdir -p $GRADLE_USER_HOME
     - set -x
     - GRADLE_FLAGS="$STANDARD_GRADLE_FLAGS $EXTRA_GRADLE_FLAGS $GRADLE_PUBLISH_ARGS $GRADLE_ARTIFACT_URL_ARGS"
     - echo $GRADLE_FLAGS


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes in this merge request. -->
Improve CI build time and enable Gradle build-cache for downstream jobs

## Changes

- Remove `--refresh-dependencies` flag from build task to improve build time
- Add Gradle build-cache to CI cache paths

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs.
- [x] Any global Gitlab variables are named distinctly so they have low-potential of conflicting with other global Gitlab variables (e.g., use "JAVA_GRADLE_ATAK_OFFLINE_IMAGE_PREFIX" instead of "IMAGE_PREFIX").
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



