### PR TITLE
Add support for configuring gradle build cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This projec
 ## [5] - on future date... somewhat unreleased but promises to have a new 5 be created for any breaking change
 ### Added
 - A `PRINT_GITLAB_CICD_VARIABLES` to various Gitlab jobs to be able to print the used Gitlab CI/CD variables for debugging purposes. 
-- Gradle CI cache path for build-cache directory.
+- Support for configuring gradle build-cache in `java-gradle-atak-offline.yml`.
 - Java Gradle ATAK Offline template jobs.
 - Dependency vulnerability scanning to Android pipeline. 
 

--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ plugin APKs as that requires the TAK.gov Gitlab CI runner to perform signing.
 | RELEASE                                       | ""                                                                                                  | Determines what type of apk should be produced. Leave blank to produce a debug apk or anything, like 'true', to create a release apk.                                                       |
 | ASSEMBLE_GRADLE_TASK (REQUIRED)               | ""                                                                                                  | Any extra gradle flags.                                                                                                                                                                     |
 | TEST_GRADLE_TASK (REQUIRED)                   | ""                                                                                                  | Any extra gradle flags.                                                                                                                                                                     |
+| GRADLE_BUILD_CACHE_FLAGS                   | "--build-cache"                                                                                              | Used to configure gradle build-cache.                                                                                                                                                       |
 
 #### Reference URL
 

--- a/lib/gitlab/ci/templates/jobs/gradle/JavaGradleAtakOffline.yml
+++ b/lib/gitlab/ci/templates/jobs/gradle/JavaGradleAtakOffline.yml
@@ -6,7 +6,13 @@ variables:
   ATAK_OFFLINE_ARTIFACT_SNAPSHOT_URL: ""
   ATAK_OFFLINE_ARTIFACT_RELEASE_URL: ""
 
-# Setup ATAK dependencies before running jobs
+  # Build cache is enabled by default for faster builds.
+  # Common issues include tasks being skipped when they should run due to undeclared inputs,
+  # and incorrect task outputs being cached permanently (re-running with clean won't fix this).
+  # If you experience unexpected build behavior, try disabling the build cache using `--no-build-cache`.
+  # Troubleshooting: https://docs.gradle.org/current/userguide/common_caching_problems.html
+  GRADLE_BUILD_CACHE_FLAGS: "--build-cache"
+
 .template-gradle-atak-repos:
   variables:
     STANDARD_GRADLE_FLAGS: '-s --no-daemon -PnoMavenLocal --console=plain'
@@ -21,6 +27,7 @@ variables:
     paths:
       - .gradle/wrapper
       - .gradle/caches
+      # Build cache directory is only used when gradle build-cache is enabled
       - .gradle/build-cache-*
   script:
     # Setup gradlew permissions in case it is not already executable
@@ -28,7 +35,7 @@ variables:
     - export GRADLE_USER_HOME=$CI_PROJECT_DIR/.gradle
     - mkdir -p $GRADLE_USER_HOME
     - set -x
-    - GRADLE_FLAGS="$STANDARD_GRADLE_FLAGS $EXTRA_GRADLE_FLAGS $GRADLE_PUBLISH_ARGS $GRADLE_ARTIFACT_URL_ARGS"
+    - GRADLE_FLAGS="$STANDARD_GRADLE_FLAGS $EXTRA_GRADLE_FLAGS $GRADLE_PUBLISH_ARGS $GRADLE_ARTIFACT_URL_ARGS $GRADLE_BUILD_CACHE_FLAGS"
     - echo $GRADLE_FLAGS
     - mkdir -p .gradle/init.d
     - |


### PR DESCRIPTION
## Description
This PR supports configuring Gradle build-cache.

<!-- Provide a brief summary of the changes in this merge request. -->

It primarily serves users who aren't familiar with Gradle build-cache. Unlike Gradle's wrapper and dependency cache, the build-cache is something developers must manually enable. The build-cache isn't perfect though, so I've linked Gradle's documentation for troubleshooting common problems.

The flag is enabled by default because I've seen huge improvements to our CI build times using the build-cache. I think the benefits of the build-cache outweigh the potential issues.

## Changes

<!-- List the main changes made in this merge request. -->
- add flag to switch build-cache modes

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [x] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [x] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs.
- [x] Any global Gitlab variables are named distinctly so they have low-potential of conflicting with other global Gitlab variables (e.g., use "JAVA_GRADLE_ATAK_OFFLINE_IMAGE_PREFIX" instead of "IMAGE_PREFIX").
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.



