### PR TITLE
Bug/fix bash gitlab release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Changed
+- The bash code in jobs/gitlab/GitlabRelease to be in Posix to work on the newest glab image.
+
+
 ## [5] - on future date... somewhat unreleased but promises to have a new 5 be created for any breaking change
 ### Added
 - A `PRINT_GITLAB_CICD_VARIABLES` to various Gitlab jobs to be able to print the used Gitlab CI/CD variables for debugging purposes. 

--- a/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
+++ b/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
@@ -12,7 +12,7 @@ gitlab_release:
       when: never
     - if: $CI_COMMIT_TAG # Run this job when a tag is created
   script:
-    - if [[ "$PRINT_GITLAB_CICD_VARIABLES" =~ ^(true|True|TRUE|yes|Yes|YES|1)$ ]]; then echo "Printing all GitLab CI/CD variables:"; env; fi
+    - case "$PRINT_GITLAB_CICD_VARIABLES" in true|True|TRUE|yes|Yes|YES|1) echo "Printing all GitLab CI/CD variables:"; env ;; esac
     - echo "Running release job for $CI_COMMIT_TAG"
     - echo "Using release flags $GITLAB_RELEASE_CLI_FLAGS"
     - echo "Dynamic flags from dotenv variables.env $GITLAB_RELEASE_CLI_FLAGS_EXTRA_DYNAMIC"

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,6 +1,6 @@
 include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/refs/heads/bug/fix-bash-gitlab-release/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml

--- a/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
+++ b/lib/gitlab/ci/templates/pipeline/AndroidTemplate.yml
@@ -1,6 +1,6 @@
 include:
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gradle/AndroidInstrumentationTests.yml
-  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
+  - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/refs/heads/bug/fix-bash-gitlab-release/lib/gitlab/ci/templates/jobs/gitlab/GitlabRelease.yml
   - remote: https://raw.githubusercontent.com/chesapeaketechnology/gitlab-templates/release/5/lib/gitlab/ci/templates/jobs/slack/SlackAPKDeployment.yml
   - template: Jobs/Secret-Detection.gitlab-ci.yml
   - template: Jobs/SAST.gitlab-ci.yml


### PR DESCRIPTION
## Description

Fix GitlabRelease to work on newest glab image. This required a switch from bash to postix

Tested with a demo release of Android app that was previously failing.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes against a Gitlab repo such as the CTI Getting Started Golden Path Templates.
- [x] My changes generate no new warnings.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation such as the README.md such as for new or changed variables.
- [x] I have added notes to the CHANGELOG.md file.
- [x] If I have edited a Gitlab job, I ensure the Gitlab job template can run independently of a Gitlab pipeline template. 
- [ ] I have ensured that if needed a downstream Gitlab job including my Gitlab job template can override the before_script and the Gitlab job template will still work.
- [ ] If possible I have used images in the Gitlab jobs that are debian, not alpine, so commands like "apt-get" not "apk" can be consistent across Gitlab jobs.
- [ ] Any global Gitlab variables are named distinctly so they have low-potential of conflicting with other global Gitlab variables (e.g., use "JAVA_GRADLE_ATAK_OFFLINE_IMAGE_PREFIX" instead of "IMAGE_PREFIX").
- [x] My changes are not breaking changes, or if they are I have created a new release/<new-version>.x.x branch.
- [ ] Any Docker/container image references is using a full SHA, not a version tag, to avoid supply-chain security attacks. 



